### PR TITLE
Add RULER-64k and RULER-128k benchmarks

### DIFF
--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -18,6 +18,8 @@ from . import (
     ruler,
     ruler16k,
     ruler32k,
+    ruler64k,
+    ruler128k,
     zero_scrolls,
 )
 
@@ -66,4 +68,6 @@ __all__ = [
     "zero_scrolls",
     "ruler32k",
     "ruler16k",
+    "ruler64k",
+    "ruler128k",
 ]

--- a/benchmark/ruler128k/__init__.py
+++ b/benchmark/ruler128k/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Ruler benchmark module for evaluating long context understanding.
+"""
+
+from .calculate_metrics import calculate_metrics
+from .ruler128k import Ruler128K
+
+__all__ = ["calculate_metrics", "Ruler128K"]

--- a/benchmark/ruler128k/calculate_metrics.py
+++ b/benchmark/ruler128k/calculate_metrics.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import re
+
+import pandas as pd
+
+
+def string_match_part(preds, refs):
+    score = (
+        sum(
+            [
+                max([1.0 if r.lower() in pred.lower() else 0.0 for r in ref])
+                for pred, ref in zip(preds, refs)
+            ]
+        )
+        / len(preds)
+        * 100
+    )
+    return round(score, 2)
+
+
+def string_match_all(preds, refs):
+    score = (
+        sum(
+            [
+                sum([1.0 if r.lower() in pred.lower() else 0.0 for r in ref]) / len(ref)
+                for pred, ref in zip(preds, refs)
+            ]
+        )
+        / len(preds)
+        * 100
+    )
+    return round(score, 2)
+
+
+def calculate_metrics(df: pd.DataFrame) -> dict:
+    scores = {}
+
+    np_pattern = re.compile(r"[\x00-\x1f]")
+    df["predicted_answer"] = df["predicted_answer"].apply(
+        lambda x: np_pattern.sub("", x.strip()).strip()
+    )
+
+    for task, df_task in df.groupby("task"):
+        task_category = task.split("_")[0]
+        metric_fn = string_match_part if task_category == "qa" else string_match_all
+        preds = df_task["predicted_answer"].tolist()
+        refs = df_task["answer"].tolist()
+        score = metric_fn(preds, refs)
+        scores[task] = {"string_match": score}
+    return scores

--- a/benchmark/ruler128k/prepare_dataframe.py
+++ b/benchmark/ruler128k/prepare_dataframe.py
@@ -70,11 +70,13 @@ def split_context_question(text: str, task: str) -> Tuple[str, str, str]:
 
     ``context + question + answer_prefix == text`` holds exactly.
 
-    The ``cwe`` and ``qa_*`` templates state their instruction twice -- once as a
-    preamble before the haystack and once again as the real question -- so the
-    *last* match is the boundary.  Using the first match would move the entire
-    document set into ``question`` and leave a two-sentence ``context``, which
-    produces plausible-looking but meaningless scores.
+    Three of the five families state their question anchor twice, so the *last*
+    match is the boundary: ``cwe`` and ``qa_*`` repeat the instruction as a
+    preamble before the haystack, and ``vt`` carries a fully worked one-shot
+    example near the top of the prompt.  Using the first match would move the
+    entire haystack into ``question`` and leave a stub ``context`` -- measured
+    on the real 64k data, 0.4% of the prompt for ``vt`` and two sentences for
+    ``cwe``/``qa_*`` -- which produces plausible-looking but meaningless scores.
 
     Args:
         text: The raw RULER sample text.

--- a/benchmark/ruler128k/prepare_dataframe.py
+++ b/benchmark/ruler128k/prepare_dataframe.py
@@ -70,13 +70,16 @@ def split_context_question(text: str, task: str) -> Tuple[str, str, str]:
 
     ``context + question + answer_prefix == text`` holds exactly.
 
-    Three of the five families state their question anchor twice, so the *last*
-    match is the boundary: ``cwe`` and ``qa_*`` repeat the instruction as a
-    preamble before the haystack, and ``vt`` carries a fully worked one-shot
-    example near the top of the prompt.  Using the first match would move the
-    entire haystack into ``question`` and leave a stub ``context`` -- measured
-    on the real 64k data, 0.4% of the prompt for ``vt`` and two sentences for
-    ``cwe``/``qa_*`` -- which produces plausible-looking but meaningless scores.
+    Three of the five families carry their question anchor twice, so the *last*
+    match is the boundary.  ``qa_1``/``qa_2`` open with the instruction and
+    restate it before the real question; ``cwe`` and ``vt`` each embed a fully
+    worked one-shot example whose own question matches the anchor.
+
+    Using the first match would move the whole haystack into ``question`` and
+    leave a stub ``context``.  Measured over all 500 rows of the real 64k data:
+    an EMPTY context for ``qa_1``/``qa_2`` (first anchor at character 0 in every
+    row), 0.44% of the prompt for ``vt`` (character 1079 of 244718) and 1.3-1.6%
+    for ``cwe``.  That scores plausibly and means nothing.
 
     Args:
         text: The raw RULER sample text.

--- a/benchmark/ruler128k/prepare_dataframe.py
+++ b/benchmark/ruler128k/prepare_dataframe.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Split raw RULER samples into the columns the benchmark harness expects.
+
+The upstream dataset for this context length stores each sample as a single raw
+``input`` string -- context, question and answer prefix already concatenated,
+with no chat template applied.  ``ruler16k`` / ``ruler32k`` consume a pre-split
+dataset because ``ruler32k/create_huggingface_dataset.py`` performed this same
+split offline before pushing to the Hub; no such pre-split dataset exists for
+64k / 128k, so the split happens here at load time using the same anchors.
+
+Keeping the split identical to the offline one is what makes the 16k / 32k /
+64k / 128k numbers comparable: the question is held out of ``context``, so a KV
+compressor that only sees ``context`` remains query-agnostic.
+"""
+
+import re
+from typing import List, Tuple
+
+import pandas as pd
+
+# Source: https://github.com/hsiehjackson/RULER/blob/main/scripts/data/synthetic/constants.py
+
+QUESTION_PATTERNS = {
+    "niah": re.compile(r"What (?:is|are all) the special magic"),
+    "vt": re.compile(r"Question: Find all variables that are assigned the value"),
+    "cwe": re.compile(
+        r"Question: What are the 10 most common words in the above list\?"
+    ),
+    "fwe": re.compile(r"Question: Do not provide any explanation\."),
+    "qa": re.compile(r"Answer the question based on the given documents\."),
+}
+
+ANSWER_PATTERNS = {
+    "niah": re.compile(r"The special magic"),
+    "vt": re.compile(r"Answer:"),
+    "cwe": re.compile(r"Answer:"),
+    "fwe": re.compile(r"Answer:"),
+    "qa": re.compile(r"Answer:"),
+}
+
+# Source: https://github.com/hsiehjackson/RULER/blob/main/scripts/data/synthetic/constants.py
+MAX_NEW_TOKENS = {
+    "niah": 128,
+    "vt": 30,
+    "cwe": 120,
+    "fwe": 50,
+    "qa": 32,
+}
+
+# The exact schema (and column order) that ruler16k / ruler32k expose.
+OUTPUT_COLUMNS: List[str] = [
+    "context",
+    "question",
+    "answer_prefix",
+    "answer",
+    "task",
+    "max_new_tokens",
+    "context_length",
+]
+
+
+class RulerSplitError(ValueError):
+    """A raw RULER sample did not contain the expected question/answer anchors."""
+
+
+def split_context_question(text: str, task: str) -> Tuple[str, str, str]:
+    """Split a raw RULER ``input`` into ``(context, question, answer_prefix)``.
+
+    ``context + question + answer_prefix == text`` holds exactly.
+
+    The ``cwe`` and ``qa_*`` templates state their instruction twice -- once as a
+    preamble before the haystack and once again as the real question -- so the
+    *last* match is the boundary.  Using the first match would move the entire
+    document set into ``question`` and leave a two-sentence ``context``, which
+    produces plausible-looking but meaningless scores.
+
+    Args:
+        text: The raw RULER sample text.
+        task: Task name, e.g. ``"niah_multikey_2"``.  Only its family prefix is
+            used to pick the anchors.
+
+    Returns:
+        Tuple of ``(context, question, answer_prefix)``.
+
+    Raises:
+        RulerSplitError: If either anchor is missing.  Never returns a
+            partially-split sample, and never drops one.
+    """
+    family: str = task.split("_")[0]
+    question_pattern = QUESTION_PATTERNS[family]
+    answer_pattern = ANSWER_PATTERNS[family]
+
+    question_matches = list(question_pattern.finditer(text))
+    if not question_matches:
+        raise RulerSplitError(
+            f"task={task}: question anchor {question_pattern.pattern!r} not found "
+            f"in a sample of {len(text)} chars; tail={text[-200:]!r}"
+        )
+    index: int = question_matches[-1].start()
+    context, question_and_answer = text[:index], text[index:]
+
+    answer_match = answer_pattern.search(question_and_answer)
+    if answer_match is None:
+        raise RulerSplitError(
+            f"task={task}: answer anchor {answer_pattern.pattern!r} not found after "
+            f"the question anchor; question_and_answer={question_and_answer!r}"
+        )
+    index = answer_match.start()
+    question = question_and_answer[:index]
+    answer_prefix = question_and_answer[index:]
+    return context, question, answer_prefix
+
+
+def prepare_dataframe(df: pd.DataFrame, task: str, context_length: int) -> pd.DataFrame:
+    """Convert a raw RULER dataframe into the schema ``Benchmark`` expects.
+
+    Args:
+        df: ``to_pandas()`` of one upstream split, with columns
+            ``index, input, outputs, length``.  Mutated in place rather than
+            copied: a single 128k split holds roughly 660 MB of strings.
+        task: Split name, e.g. ``"niah_multikey_2"``.
+        context_length: Nominal context length, recorded on every row.
+
+    Returns:
+        DataFrame containing exactly ``OUTPUT_COLUMNS``, in that order.
+
+    Raises:
+        RulerSplitError: If any row fails to split.  Rows are never dropped --
+            silently shrinking the sample would shrink the scoring denominator
+            too, and produce a normal-looking score over fewer rows.
+    """
+    if len(df) == 0:
+        return pd.DataFrame(columns=OUTPUT_COLUMNS)
+
+    df["context"], df["question"], df["answer_prefix"] = zip(
+        *(split_context_question(text, task) for text in df["input"])
+    )
+    df["task"] = task
+    df["max_new_tokens"] = MAX_NEW_TOKENS[task.split("_")[0]]
+    df["context_length"] = context_length
+    df = df.rename(columns={"outputs": "answer"})
+    return df[OUTPUT_COLUMNS]

--- a/benchmark/ruler128k/ruler128k.py
+++ b/benchmark/ruler128k/ruler128k.py
@@ -1,0 +1,159 @@
+"""Ruler benchmark implementation for long context evaluation."""
+
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from ..base import Benchmark
+from ..benchmark_registry import register_benchmark
+from .calculate_metrics import calculate_metrics
+from .prepare_dataframe import prepare_dataframe
+
+
+@register_benchmark("ruler128k")
+class Ruler128K(Benchmark):
+    """Ruler benchmark for evaluating long context understanding."""
+
+    # All available Ruler datasets (context lengths)
+    all_datasets: List[str] = [
+        "cwe",
+        "fwe",
+        "niah_multikey_1",
+        "niah_multikey_2",
+        "niah_multikey_3",
+        "niah_multiquery",
+        "niah_multivalue",
+        "niah_single_1",
+        "niah_single_2",
+        "niah_single_3",
+        "qa_1",
+        "qa_2",
+        "vt",
+    ]
+
+    benchmark_name: str = "ruler128k"
+    huggingface_dataset_id: str = "SaylorTwift/RULER-131072-llama-3.2-tokenizer"
+
+    def _load_datasets(self) -> pd.DataFrame:
+        """Load Ruler datasets by individual splits.
+
+        Unlike ruler16k / ruler32k, the upstream dataset is *raw*: every row
+        holds a single ``input`` string and the dataset exposes one ``default``
+        config whose splits are the RULER task names.  ``prepare_dataframe``
+        re-applies the official RULER anchors to recover context / question /
+        answer_prefix at load time.
+
+        Returns:
+            Combined pandas DataFrame with all samples from subsets_to_run.
+        """
+        print(f"Loading Ruler datasets: {self.subsets_to_run}")
+        dfs = []
+        failed_subsets: List[str] = []
+
+        for subset in self.subsets_to_run:
+            try:
+                from datasets import load_dataset
+
+                subset_dataset = load_dataset(self.huggingface_dataset_id, split=subset)
+                # Splits the raw `input` column and stamps context_length.
+                subset_df = prepare_dataframe(
+                    subset_dataset.to_pandas(), subset, 131072
+                )
+                dfs.append(subset_df)
+                print(
+                    f"  ✓ Loaded {len(subset_df)} samples from {subset} || context_length = 131072"
+                )
+            except Exception as subset_error:
+                failed_subsets.append(subset)
+                print(f"  ❌ Failed to load {subset}: {str(subset_error)}")
+                continue
+
+        if not dfs:
+            raise Exception("No Ruler subsets could be loaded successfully")
+
+        # Combine all subset DataFrames
+        import pandas as pd
+
+        combined_df = pd.concat(dfs, ignore_index=True)
+        if failed_subsets:
+            # post_run_evaluate averages over the tasks that are present, so a
+            # skipped subset silently changes overall_score. Say so loudly.
+            print(
+                f"  ⚠️  {len(failed_subsets)} subset(s) skipped and NOT included in "
+                f"the reported scores: {failed_subsets}"
+            )
+        print(
+            f"Combined {len(combined_df)} total samples from {len(dfs)} subsets || context_length = 131072"
+        )
+        return combined_df
+
+    def post_run_evaluate(self, results_df: pd.DataFrame) -> Dict[str, Any]:
+        """Compute evaluation metrics for Ruler results.
+
+        Args:
+            results_df: DataFrame containing benchmark results with columns:
+                - task: Dataset/task name
+                - predicted_answer: Model's predicted answer
+                - answer: Ground truth answers
+                - context_length: Context length used
+
+        Returns:
+            Dictionary containing computed metrics:
+            - overall_score: Average score across all tasks
+            - task_scores: Individual scores for each task
+            - context_length_scores: Scores grouped by context length
+        """
+        if len(results_df) == 0:
+            return {"error": "No results to evaluate"}
+
+        # Use the calculate_metrics function from HashAttention evaluation
+        task_scores: Dict[str, Dict[str, float]] = calculate_metrics(results_df)
+
+        # Extract string_match scores and compute overall
+        all_scores: List[float] = []
+        for task, scores in task_scores.items():
+            if "string_match" in scores:
+                all_scores.append(scores["string_match"])
+
+        overall_score = sum(all_scores) / len(all_scores) if all_scores else 0.0
+
+        # Group by context length if available
+        context_length_scores: Dict[str, float] = {}
+        if "context_length" in results_df.columns:
+            for context_length in results_df["context_length"].unique():
+                try:
+                    length_df = results_df[
+                        results_df["context_length"] == context_length
+                    ]
+                    if len(length_df) > 0:
+                        length_scores = calculate_metrics(length_df)
+                        length_overall = (
+                            sum(
+                                score.get("string_match", 0)
+                                for score in length_scores.values()
+                            )
+                            / len(length_scores)
+                            if length_scores
+                            else 0.0
+                        )
+                        context_length_scores[str(context_length)] = round(
+                            length_overall, 2
+                        )
+                except Exception as e:
+                    print(
+                        f"Warning: Failed to compute metrics for context length {context_length}: {e}"
+                    )
+                    continue
+
+        overall_metrics: Dict[str, Any] = {
+            "overall_score": round(overall_score, 2),
+            "task_scores": task_scores,
+            "context_length_scores": context_length_scores,
+            "summary": {
+                "total_tasks": len(task_scores),
+                "total_samples": len(results_df),
+                "context_lengths": list(context_length_scores.keys()),
+            },
+        }
+
+        return overall_metrics

--- a/benchmark/ruler64k/__init__.py
+++ b/benchmark/ruler64k/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Ruler benchmark module for evaluating long context understanding.
+"""
+
+from .calculate_metrics import calculate_metrics
+from .ruler64k import Ruler64K
+
+__all__ = ["calculate_metrics", "Ruler64K"]

--- a/benchmark/ruler64k/calculate_metrics.py
+++ b/benchmark/ruler64k/calculate_metrics.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import re
+
+import pandas as pd
+
+
+def string_match_part(preds, refs):
+    score = (
+        sum(
+            [
+                max([1.0 if r.lower() in pred.lower() else 0.0 for r in ref])
+                for pred, ref in zip(preds, refs)
+            ]
+        )
+        / len(preds)
+        * 100
+    )
+    return round(score, 2)
+
+
+def string_match_all(preds, refs):
+    score = (
+        sum(
+            [
+                sum([1.0 if r.lower() in pred.lower() else 0.0 for r in ref]) / len(ref)
+                for pred, ref in zip(preds, refs)
+            ]
+        )
+        / len(preds)
+        * 100
+    )
+    return round(score, 2)
+
+
+def calculate_metrics(df: pd.DataFrame) -> dict:
+    scores = {}
+
+    np_pattern = re.compile(r"[\x00-\x1f]")
+    df["predicted_answer"] = df["predicted_answer"].apply(
+        lambda x: np_pattern.sub("", x.strip()).strip()
+    )
+
+    for task, df_task in df.groupby("task"):
+        task_category = task.split("_")[0]
+        metric_fn = string_match_part if task_category == "qa" else string_match_all
+        preds = df_task["predicted_answer"].tolist()
+        refs = df_task["answer"].tolist()
+        score = metric_fn(preds, refs)
+        scores[task] = {"string_match": score}
+    return scores

--- a/benchmark/ruler64k/prepare_dataframe.py
+++ b/benchmark/ruler64k/prepare_dataframe.py
@@ -70,11 +70,13 @@ def split_context_question(text: str, task: str) -> Tuple[str, str, str]:
 
     ``context + question + answer_prefix == text`` holds exactly.
 
-    The ``cwe`` and ``qa_*`` templates state their instruction twice -- once as a
-    preamble before the haystack and once again as the real question -- so the
-    *last* match is the boundary.  Using the first match would move the entire
-    document set into ``question`` and leave a two-sentence ``context``, which
-    produces plausible-looking but meaningless scores.
+    Three of the five families state their question anchor twice, so the *last*
+    match is the boundary: ``cwe`` and ``qa_*`` repeat the instruction as a
+    preamble before the haystack, and ``vt`` carries a fully worked one-shot
+    example near the top of the prompt.  Using the first match would move the
+    entire haystack into ``question`` and leave a stub ``context`` -- measured
+    on the real 64k data, 0.4% of the prompt for ``vt`` and two sentences for
+    ``cwe``/``qa_*`` -- which produces plausible-looking but meaningless scores.
 
     Args:
         text: The raw RULER sample text.

--- a/benchmark/ruler64k/prepare_dataframe.py
+++ b/benchmark/ruler64k/prepare_dataframe.py
@@ -70,13 +70,16 @@ def split_context_question(text: str, task: str) -> Tuple[str, str, str]:
 
     ``context + question + answer_prefix == text`` holds exactly.
 
-    Three of the five families state their question anchor twice, so the *last*
-    match is the boundary: ``cwe`` and ``qa_*`` repeat the instruction as a
-    preamble before the haystack, and ``vt`` carries a fully worked one-shot
-    example near the top of the prompt.  Using the first match would move the
-    entire haystack into ``question`` and leave a stub ``context`` -- measured
-    on the real 64k data, 0.4% of the prompt for ``vt`` and two sentences for
-    ``cwe``/``qa_*`` -- which produces plausible-looking but meaningless scores.
+    Three of the five families carry their question anchor twice, so the *last*
+    match is the boundary.  ``qa_1``/``qa_2`` open with the instruction and
+    restate it before the real question; ``cwe`` and ``vt`` each embed a fully
+    worked one-shot example whose own question matches the anchor.
+
+    Using the first match would move the whole haystack into ``question`` and
+    leave a stub ``context``.  Measured over all 500 rows of the real 64k data:
+    an EMPTY context for ``qa_1``/``qa_2`` (first anchor at character 0 in every
+    row), 0.44% of the prompt for ``vt`` (character 1079 of 244718) and 1.3-1.6%
+    for ``cwe``.  That scores plausibly and means nothing.
 
     Args:
         text: The raw RULER sample text.

--- a/benchmark/ruler64k/prepare_dataframe.py
+++ b/benchmark/ruler64k/prepare_dataframe.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Split raw RULER samples into the columns the benchmark harness expects.
+
+The upstream dataset for this context length stores each sample as a single raw
+``input`` string -- context, question and answer prefix already concatenated,
+with no chat template applied.  ``ruler16k`` / ``ruler32k`` consume a pre-split
+dataset because ``ruler32k/create_huggingface_dataset.py`` performed this same
+split offline before pushing to the Hub; no such pre-split dataset exists for
+64k / 128k, so the split happens here at load time using the same anchors.
+
+Keeping the split identical to the offline one is what makes the 16k / 32k /
+64k / 128k numbers comparable: the question is held out of ``context``, so a KV
+compressor that only sees ``context`` remains query-agnostic.
+"""
+
+import re
+from typing import List, Tuple
+
+import pandas as pd
+
+# Source: https://github.com/hsiehjackson/RULER/blob/main/scripts/data/synthetic/constants.py
+
+QUESTION_PATTERNS = {
+    "niah": re.compile(r"What (?:is|are all) the special magic"),
+    "vt": re.compile(r"Question: Find all variables that are assigned the value"),
+    "cwe": re.compile(
+        r"Question: What are the 10 most common words in the above list\?"
+    ),
+    "fwe": re.compile(r"Question: Do not provide any explanation\."),
+    "qa": re.compile(r"Answer the question based on the given documents\."),
+}
+
+ANSWER_PATTERNS = {
+    "niah": re.compile(r"The special magic"),
+    "vt": re.compile(r"Answer:"),
+    "cwe": re.compile(r"Answer:"),
+    "fwe": re.compile(r"Answer:"),
+    "qa": re.compile(r"Answer:"),
+}
+
+# Source: https://github.com/hsiehjackson/RULER/blob/main/scripts/data/synthetic/constants.py
+MAX_NEW_TOKENS = {
+    "niah": 128,
+    "vt": 30,
+    "cwe": 120,
+    "fwe": 50,
+    "qa": 32,
+}
+
+# The exact schema (and column order) that ruler16k / ruler32k expose.
+OUTPUT_COLUMNS: List[str] = [
+    "context",
+    "question",
+    "answer_prefix",
+    "answer",
+    "task",
+    "max_new_tokens",
+    "context_length",
+]
+
+
+class RulerSplitError(ValueError):
+    """A raw RULER sample did not contain the expected question/answer anchors."""
+
+
+def split_context_question(text: str, task: str) -> Tuple[str, str, str]:
+    """Split a raw RULER ``input`` into ``(context, question, answer_prefix)``.
+
+    ``context + question + answer_prefix == text`` holds exactly.
+
+    The ``cwe`` and ``qa_*`` templates state their instruction twice -- once as a
+    preamble before the haystack and once again as the real question -- so the
+    *last* match is the boundary.  Using the first match would move the entire
+    document set into ``question`` and leave a two-sentence ``context``, which
+    produces plausible-looking but meaningless scores.
+
+    Args:
+        text: The raw RULER sample text.
+        task: Task name, e.g. ``"niah_multikey_2"``.  Only its family prefix is
+            used to pick the anchors.
+
+    Returns:
+        Tuple of ``(context, question, answer_prefix)``.
+
+    Raises:
+        RulerSplitError: If either anchor is missing.  Never returns a
+            partially-split sample, and never drops one.
+    """
+    family: str = task.split("_")[0]
+    question_pattern = QUESTION_PATTERNS[family]
+    answer_pattern = ANSWER_PATTERNS[family]
+
+    question_matches = list(question_pattern.finditer(text))
+    if not question_matches:
+        raise RulerSplitError(
+            f"task={task}: question anchor {question_pattern.pattern!r} not found "
+            f"in a sample of {len(text)} chars; tail={text[-200:]!r}"
+        )
+    index: int = question_matches[-1].start()
+    context, question_and_answer = text[:index], text[index:]
+
+    answer_match = answer_pattern.search(question_and_answer)
+    if answer_match is None:
+        raise RulerSplitError(
+            f"task={task}: answer anchor {answer_pattern.pattern!r} not found after "
+            f"the question anchor; question_and_answer={question_and_answer!r}"
+        )
+    index = answer_match.start()
+    question = question_and_answer[:index]
+    answer_prefix = question_and_answer[index:]
+    return context, question, answer_prefix
+
+
+def prepare_dataframe(df: pd.DataFrame, task: str, context_length: int) -> pd.DataFrame:
+    """Convert a raw RULER dataframe into the schema ``Benchmark`` expects.
+
+    Args:
+        df: ``to_pandas()`` of one upstream split, with columns
+            ``index, input, outputs, length``.  Mutated in place rather than
+            copied: a single 128k split holds roughly 660 MB of strings.
+        task: Split name, e.g. ``"niah_multikey_2"``.
+        context_length: Nominal context length, recorded on every row.
+
+    Returns:
+        DataFrame containing exactly ``OUTPUT_COLUMNS``, in that order.
+
+    Raises:
+        RulerSplitError: If any row fails to split.  Rows are never dropped --
+            silently shrinking the sample would shrink the scoring denominator
+            too, and produce a normal-looking score over fewer rows.
+    """
+    if len(df) == 0:
+        return pd.DataFrame(columns=OUTPUT_COLUMNS)
+
+    df["context"], df["question"], df["answer_prefix"] = zip(
+        *(split_context_question(text, task) for text in df["input"])
+    )
+    df["task"] = task
+    df["max_new_tokens"] = MAX_NEW_TOKENS[task.split("_")[0]]
+    df["context_length"] = context_length
+    df = df.rename(columns={"outputs": "answer"})
+    return df[OUTPUT_COLUMNS]

--- a/benchmark/ruler64k/ruler64k.py
+++ b/benchmark/ruler64k/ruler64k.py
@@ -1,0 +1,157 @@
+"""Ruler benchmark implementation for long context evaluation."""
+
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from ..base import Benchmark
+from ..benchmark_registry import register_benchmark
+from .calculate_metrics import calculate_metrics
+from .prepare_dataframe import prepare_dataframe
+
+
+@register_benchmark("ruler64k")
+class Ruler64K(Benchmark):
+    """Ruler benchmark for evaluating long context understanding."""
+
+    # All available Ruler datasets (context lengths)
+    all_datasets: List[str] = [
+        "cwe",
+        "fwe",
+        "niah_multikey_1",
+        "niah_multikey_2",
+        "niah_multikey_3",
+        "niah_multiquery",
+        "niah_multivalue",
+        "niah_single_1",
+        "niah_single_2",
+        "niah_single_3",
+        "qa_1",
+        "qa_2",
+        "vt",
+    ]
+
+    benchmark_name: str = "ruler64k"
+    huggingface_dataset_id: str = "SaylorTwift/RULER-65536-llama-3.2-tokenizer"
+
+    def _load_datasets(self) -> pd.DataFrame:
+        """Load Ruler datasets by individual splits.
+
+        Unlike ruler16k / ruler32k, the upstream dataset is *raw*: every row
+        holds a single ``input`` string and the dataset exposes one ``default``
+        config whose splits are the RULER task names.  ``prepare_dataframe``
+        re-applies the official RULER anchors to recover context / question /
+        answer_prefix at load time.
+
+        Returns:
+            Combined pandas DataFrame with all samples from subsets_to_run.
+        """
+        print(f"Loading Ruler datasets: {self.subsets_to_run}")
+        dfs = []
+        failed_subsets: List[str] = []
+
+        for subset in self.subsets_to_run:
+            try:
+                from datasets import load_dataset
+
+                subset_dataset = load_dataset(self.huggingface_dataset_id, split=subset)
+                # Splits the raw `input` column and stamps context_length.
+                subset_df = prepare_dataframe(subset_dataset.to_pandas(), subset, 65536)
+                dfs.append(subset_df)
+                print(
+                    f"  ✓ Loaded {len(subset_df)} samples from {subset} || context_length = 65536"
+                )
+            except Exception as subset_error:
+                failed_subsets.append(subset)
+                print(f"  ❌ Failed to load {subset}: {str(subset_error)}")
+                continue
+
+        if not dfs:
+            raise Exception("No Ruler subsets could be loaded successfully")
+
+        # Combine all subset DataFrames
+        import pandas as pd
+
+        combined_df = pd.concat(dfs, ignore_index=True)
+        if failed_subsets:
+            # post_run_evaluate averages over the tasks that are present, so a
+            # skipped subset silently changes overall_score. Say so loudly.
+            print(
+                f"  ⚠️  {len(failed_subsets)} subset(s) skipped and NOT included in "
+                f"the reported scores: {failed_subsets}"
+            )
+        print(
+            f"Combined {len(combined_df)} total samples from {len(dfs)} subsets || context_length = 65536"
+        )
+        return combined_df
+
+    def post_run_evaluate(self, results_df: pd.DataFrame) -> Dict[str, Any]:
+        """Compute evaluation metrics for Ruler results.
+
+        Args:
+            results_df: DataFrame containing benchmark results with columns:
+                - task: Dataset/task name
+                - predicted_answer: Model's predicted answer
+                - answer: Ground truth answers
+                - context_length: Context length used
+
+        Returns:
+            Dictionary containing computed metrics:
+            - overall_score: Average score across all tasks
+            - task_scores: Individual scores for each task
+            - context_length_scores: Scores grouped by context length
+        """
+        if len(results_df) == 0:
+            return {"error": "No results to evaluate"}
+
+        # Use the calculate_metrics function from HashAttention evaluation
+        task_scores: Dict[str, Dict[str, float]] = calculate_metrics(results_df)
+
+        # Extract string_match scores and compute overall
+        all_scores: List[float] = []
+        for task, scores in task_scores.items():
+            if "string_match" in scores:
+                all_scores.append(scores["string_match"])
+
+        overall_score = sum(all_scores) / len(all_scores) if all_scores else 0.0
+
+        # Group by context length if available
+        context_length_scores: Dict[str, float] = {}
+        if "context_length" in results_df.columns:
+            for context_length in results_df["context_length"].unique():
+                try:
+                    length_df = results_df[
+                        results_df["context_length"] == context_length
+                    ]
+                    if len(length_df) > 0:
+                        length_scores = calculate_metrics(length_df)
+                        length_overall = (
+                            sum(
+                                score.get("string_match", 0)
+                                for score in length_scores.values()
+                            )
+                            / len(length_scores)
+                            if length_scores
+                            else 0.0
+                        )
+                        context_length_scores[str(context_length)] = round(
+                            length_overall, 2
+                        )
+                except Exception as e:
+                    print(
+                        f"Warning: Failed to compute metrics for context length {context_length}: {e}"
+                    )
+                    continue
+
+        overall_metrics: Dict[str, Any] = {
+            "overall_score": round(overall_score, 2),
+            "task_scores": task_scores,
+            "context_length_scores": context_length_scores,
+            "summary": {
+                "total_tasks": len(task_scores),
+                "total_samples": len(results_df),
+                "context_lengths": list(context_length_scores.keys()),
+            },
+        }
+
+        return overall_metrics

--- a/sparse_attention_hub/adapters/huggingface.py
+++ b/sparse_attention_hub/adapters/huggingface.py
@@ -141,7 +141,17 @@ class ModelAdapterHF(ModelAdapter):
             context, questions, answer_prefix
         )
 
-        context_tokens = self.tokenizer.encode(context, return_tensors="pt")
+        # `_preprocess_context_and_questions` may have already applied the chat
+        # template, which emits the model's BOS itself. Several fast tokenizers
+        # (Llama-3.x, Gemma) carry a `TemplateProcessing` post-processor that
+        # prepends BOS on *every* `encode()` regardless of `add_bos_token`, so
+        # letting `add_special_tokens` default to True duplicates it here and
+        # splices a third one in mid-sequence at the question boundary below.
+        context_tokens = self.tokenizer.encode(
+            context,
+            return_tensors="pt",
+            add_special_tokens=self.tokenizer.chat_template is None,
+        )
         context_tokens = context_tokens[
             :, :max_context_length
         ]  # truncate context to max_context_length
@@ -159,7 +169,11 @@ class ModelAdapterHF(ModelAdapter):
             for question in questions:
                 sparse_meta_data: Dict[str, Any] = {}
 
-                question_tokens = self.tokenizer.encode(question, return_tensors="pt")
+                # The question continues the already-BOS-prefixed context; any
+                # special token added here lands mid-sequence.
+                question_tokens = self.tokenizer.encode(
+                    question, return_tensors="pt", add_special_tokens=False
+                )
                 if input_device is not None:
                     question_tokens = question_tokens.to(input_device)
 

--- a/tests/unit/adapters/test_huggingface_special_tokens.py
+++ b/tests/unit/adapters/test_huggingface_special_tokens.py
@@ -186,7 +186,8 @@ class TestProcessRequestSpecialTokens:
         assert len(calls) == 2, f"expected one context and one question encode: {calls}"
         assert calls[0].add_special_tokens is False, (
             "context encode must suppress special tokens when the chat template "
-            f"already emitted BOS; got {calls[0]!r}"
+            "already emitted BOS; got "
+            f"{calls[0]!r}"
         )
         assert calls[1].add_special_tokens is False, (
             "question encode must never add special tokens mid-sequence; got "
@@ -215,7 +216,8 @@ class TestProcessRequestSpecialTokens:
         assert len(calls) == 2, f"expected one context and one question encode: {calls}"
         assert calls[0].add_special_tokens is True, (
             "context encode must request special tokens when no chat template "
-            f"rendered a BOS; got {calls[0]!r}"
+            "rendered a BOS; got "
+            f"{calls[0]!r}"
         )
         assert calls[1].add_special_tokens is False, (
             "question encode must never add special tokens mid-sequence; got "

--- a/tests/unit/adapters/test_huggingface_special_tokens.py
+++ b/tests/unit/adapters/test_huggingface_special_tokens.py
@@ -1,0 +1,223 @@
+"""Unit tests for special-token handling in :class:`ModelAdapterHF.process_request`.
+
+``ModelAdapterHF._preprocess_context_and_questions`` renders the chat template
+with ``tokenize=False``, so the returned string already carries the model's BOS
+marker. Fast tokenizers for Llama-3.x and Gemma additionally carry a
+``TemplateProcessing`` post-processor that prepends BOS on *every* ``encode()``
+call, so leaving ``add_special_tokens`` at its default of ``True`` duplicates
+BOS at the head of the context and splices a third one in mid-sequence at the
+question boundary. These tests pin the corrected call sites.
+"""
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from sparse_attention_hub.adapters import ModelAdapterHF, Request
+from sparse_attention_hub.adapters.model_servers.base import ModelServer
+
+BOS_ID: int = 128000
+BOS_MARKER: str = "<|begin_of_text|>"
+
+
+class EncodeCall:
+    """One recorded invocation of :meth:`FakeTokenizer.encode`."""
+
+    def __init__(self, text: str, add_special_tokens: bool) -> None:
+        """Store the text and the ``add_special_tokens`` value that was used."""
+        self.text: str = text
+        self.add_special_tokens: bool = add_special_tokens
+
+    def __repr__(self) -> str:
+        """Return a compact representation useful in assertion output."""
+        return (
+            f"EncodeCall(add_special_tokens={self.add_special_tokens!r}, "
+            f"text={self.text!r})"
+        )
+
+
+class FakeTokenizer:
+    """A ``TemplateProcessing``-style tokenizer stand-in.
+
+    Two independent sources can emit a BOS id, exactly as in the real Llama-3.x
+    and Gemma fast tokenizers:
+
+    1. the literal :data:`BOS_MARKER` that ``apply_chat_template`` writes into
+       the rendered string, and
+    2. the post-processor, simulated here by prepending :data:`BOS_ID` whenever
+       ``add_special_tokens`` is true.
+
+    Every ``encode()`` call is recorded in :attr:`encode_calls` so tests can
+    assert on the keyword the adapter actually passed.
+    """
+
+    def __init__(self, chat_template: Optional[str]) -> None:
+        """Create a tokenizer whose ``chat_template`` may be ``None``."""
+        self.chat_template: Optional[str] = chat_template
+        self.pad_token: str = "<pad>"
+        self.eos_token: str = "<eos>"
+        self.bos_token_id: int = BOS_ID
+        self.encode_calls: List[EncodeCall] = []
+        self._vocab: Dict[str, int] = {}
+
+    def apply_chat_template(
+        self,
+        conversation: List[Dict[str, str]],
+        tokenize: bool = True,
+        add_generation_prompt: bool = False,
+    ) -> str:
+        """Render a Llama-3-shaped prompt, BOS marker included."""
+        assert tokenize is False, "adapter must render the template as text"
+        content: str = conversation[0]["content"]
+        return (
+            f"{BOS_MARKER}<|start_header_id|>user<|end_header_id|>\n{content}"
+            "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n"
+        )
+
+    def _word_id(self, word: str) -> int:
+        """Return a stable, BOS-free id for ``word``."""
+        if word not in self._vocab:
+            self._vocab[word] = 10 + len(self._vocab)
+        return self._vocab[word]
+
+    def encode(
+        self,
+        text: str,
+        return_tensors: Optional[str] = None,
+        add_special_tokens: bool = True,
+    ) -> Any:
+        """Encode ``text``, recording the ``add_special_tokens`` kwarg received."""
+        self.encode_calls.append(
+            EncodeCall(text=text, add_special_tokens=add_special_tokens)
+        )
+
+        ids: List[int] = [BOS_ID] if add_special_tokens else []
+        for index, segment in enumerate(text.split(BOS_MARKER)):
+            if index > 0:
+                ids.append(BOS_ID)
+            ids.extend(self._word_id(word) for word in segment.split())
+
+        if return_tensors == "pt":
+            return torch.tensor([ids], dtype=torch.long)
+        return ids
+
+
+def build_adapter(
+    mock_model_server_hf: Mock, chat_template: Optional[str]
+) -> ModelAdapterHF:
+    """Build a dense-only adapter wired to :class:`FakeTokenizer` and a mock model."""
+    tokenizer: FakeTokenizer = FakeTokenizer(chat_template=chat_template)
+
+    mock_model: Mock = Mock()
+    mock_model.device = torch.device("cpu")
+
+    mock_model_server: Mock = Mock()
+    mock_model_server.get_tokenizer.return_value = tokenizer
+    mock_model_server.get_model.return_value = mock_model
+    mock_model_server_hf.return_value = mock_model_server
+
+    return ModelAdapterHF(
+        model_name="test-model",
+        sparse_attention_config=None,
+        device="cpu",
+    )
+
+
+def run_request(adapter: ModelAdapterHF) -> torch.Tensor:
+    """Drive ``process_request`` once and return the assembled context+question ids."""
+    captured: Dict[str, torch.Tensor] = {}
+
+    def fake_generate_response(
+        question_tokens: torch.Tensor,
+        context_outputs: Any,
+        sparse_meta_data: Dict[str, Any],
+        generation_kwargs: Dict[str, Any],
+        **kwargs: Any,
+    ) -> str:
+        captured["question_tokens"] = question_tokens
+        return "answer"
+
+    adapter._generate_response = fake_generate_response  # type: ignore[assignment]
+
+    request: Request = Request(
+        context="the quick brown fox",
+        questions="who jumped ?",
+        answer_prefix="Answer:",
+    )
+    adapter.process_request(request, generation_kwargs={}, request_kwargs={})
+
+    context_tokens: torch.Tensor = adapter.model.call_args_list[0][0][0]
+    return torch.cat([context_tokens, captured["question_tokens"]], dim=1)
+
+
+@pytest.mark.unit
+class TestProcessRequestSpecialTokens:
+    """Pin the ``add_special_tokens`` contract of the two ``encode()`` call sites."""
+
+    def setup_method(self) -> None:
+        """Reset the ModelServer singleton before each test."""
+        ModelServer._instance = None
+
+    def teardown_method(self) -> None:
+        """Reset the ModelServer singleton after each test."""
+        ModelServer._instance = None
+
+    @patch("sparse_attention_hub.adapters.huggingface.ModelServerHF")
+    def test_chat_template_yields_exactly_one_bos(
+        self, mock_model_server_hf: Mock
+    ) -> None:
+        """With a chat template the template's own BOS must be the only one."""
+        adapter: ModelAdapterHF = build_adapter(
+            mock_model_server_hf, chat_template="{{ messages }}"
+        )
+        assembled: torch.Tensor = run_request(adapter)
+
+        ids: List[int] = assembled[0].tolist()
+        assert ids.count(BOS_ID) == 1, (
+            "expected exactly one BOS in the assembled sequence, got "
+            f"{ids.count(BOS_ID)} at positions "
+            f"{[i for i, t in enumerate(ids) if t == BOS_ID]}"
+        )
+        assert ids[0] == BOS_ID, "the single BOS must sit at position 0"
+
+        calls: List[EncodeCall] = adapter.tokenizer.encode_calls
+        assert len(calls) == 2, f"expected one context and one question encode: {calls}"
+        assert calls[0].add_special_tokens is False, (
+            "context encode must suppress special tokens when the chat template "
+            f"already emitted BOS; got {calls[0]!r}"
+        )
+        assert calls[1].add_special_tokens is False, (
+            "question encode must never add special tokens mid-sequence; got "
+            f"{calls[1]!r}"
+        )
+
+    @patch("sparse_attention_hub.adapters.huggingface.ModelServerHF")
+    def test_without_chat_template_context_keeps_bos(
+        self, mock_model_server_hf: Mock
+    ) -> None:
+        """Without a chat template the tokenizer must still supply the BOS."""
+        adapter: ModelAdapterHF = build_adapter(
+            mock_model_server_hf, chat_template=None
+        )
+        assembled: torch.Tensor = run_request(adapter)
+
+        ids: List[int] = assembled[0].tolist()
+        assert ids.count(BOS_ID) == 1, (
+            "expected exactly one BOS in the assembled sequence, got "
+            f"{ids.count(BOS_ID)} at positions "
+            f"{[i for i, t in enumerate(ids) if t == BOS_ID]}"
+        )
+        assert ids[0] == BOS_ID, "the single BOS must sit at position 0"
+
+        calls: List[EncodeCall] = adapter.tokenizer.encode_calls
+        assert len(calls) == 2, f"expected one context and one question encode: {calls}"
+        assert calls[0].add_special_tokens is True, (
+            "context encode must request special tokens when no chat template "
+            f"rendered a BOS; got {calls[0]!r}"
+        )
+        assert calls[1].add_special_tokens is False, (
+            "question encode must never add special tokens mid-sequence; got "
+            f"{calls[1]!r}"
+        )

--- a/tests/unit/benchmark/test_ruler128k.py
+++ b/tests/unit/benchmark/test_ruler128k.py
@@ -1,0 +1,660 @@
+"""Unit tests for Ruler128K benchmark implementation."""
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmark.ruler128k import Ruler128K
+from benchmark.ruler128k.calculate_metrics import calculate_metrics
+from benchmark.ruler128k.prepare_dataframe import (
+    MAX_NEW_TOKENS,
+    OUTPUT_COLUMNS,
+    RulerSplitError,
+    prepare_dataframe,
+    split_context_question,
+)
+
+DATASET_ID = "SaylorTwift/RULER-131072-llama-3.2-tokenizer"
+CONTEXT_LENGTH = 131072
+
+# Minimal stand-ins for the five RULER prompt families.  Each is
+# "<preamble><haystack><question><answer_prefix>" exactly as RULER emits it, so
+# split_context_question has something realistic to cut.
+_TEMPLATES = {
+    "niah": (
+        "One of the special magic numbers for pale-cactus is hidden in the "
+        "following text. Make sure to memorize it.\n"
+        "{haystack}\n"
+        "What is the special magic number for pale-cactus mentioned in the "
+        "provided text? "
+        "The special magic number for pale-cactus mentioned in the provided "
+        "text is"
+    ),
+    "vt": (
+        "Memorize and track the chain(s) of variable assignment hidden in the "
+        "following text.\n"
+        "{haystack}\n"
+        "Question: Find all variables that are assigned the value 12345 in the "
+        "text above."
+        "Answer: According to the chain(s) of variable assignment in the text "
+        "above, 5 variables are assigned the value 12345, they are: "
+    ),
+    "cwe": (
+        "Below is a numbered list of words. In these words, some appear more "
+        "often than others. Memorize the ones that appear most often.\n"
+        "Question: What are the 10 most common words in the above list?\n"
+        "{haystack}\n"
+        "Question: What are the 10 most common words in the above list? "
+        "Answer: The top 10 words that appear most often in the list are:"
+    ),
+    "fwe": (
+        "Read the following coded text and track the frequency of each coded "
+        "word.\n"
+        "{haystack}\n"
+        "Question: Do not provide any explanation. Please ignore the dots "
+        "'....'. What are the three most frequently appeared words in the "
+        "above coded text? "
+        "Answer: According to the coded text above, the three most frequently "
+        "appeared words are:"
+    ),
+    "qa": (
+        "Answer the question based on the given documents. Only give me the "
+        "answer and do not output any other words.\n\n"
+        "The following are given documents.\n\n"
+        "{haystack}\n\n"
+        "Answer the question based on the given documents. Only give me the "
+        "answer and do not output any other words.\n\n"
+        "Question: What colour is the sky? "
+        "Answer:"
+    ),
+}
+
+# Families whose instruction is stated twice: once as a context preamble and
+# once as the real trailing question.  The split must take the LAST occurrence.
+_REPEATED_ANCHOR_FAMILIES = ["cwe", "qa"]
+
+
+def _raw_input(family: str, haystack: str = "HAYSTACK " * 16) -> str:
+    """Build a synthetic raw RULER sample for one prompt family."""
+    return _TEMPLATES[family].format(haystack=haystack)
+
+
+def _raw_frame(task: str, n_rows: int = 2) -> pd.DataFrame:
+    """Build a raw upstream frame (index / input / outputs / length)."""
+    family = task.split("_")[0]
+    return pd.DataFrame(
+        {
+            "index": list(range(n_rows)),
+            "input": [_raw_input(family) for _ in range(n_rows)],
+            "outputs": [np.array(["gold"], dtype=object) for _ in range(n_rows)],
+            "length": [CONTEXT_LENGTH] * n_rows,
+        }
+    )
+
+
+def _mock_dataset(task: str, n_rows: int = 2) -> Mock:
+    """A Mock standing in for a loaded HuggingFace split."""
+    dataset = Mock()
+    dataset.to_pandas.return_value = _raw_frame(task, n_rows)
+    return dataset
+
+
+class TestRuler128KUnit:
+    """Unit tests for Ruler128K class."""
+
+    def test_ruler128k_initialization(self):
+        """Test Ruler128K initialization."""
+        ruler128k = Ruler128K()
+        assert len(ruler128k.all_datasets) == 13
+        assert ruler128k.benchmark_name == "ruler128k"
+        assert ruler128k.huggingface_dataset_id == DATASET_ID
+
+    def test_ruler128k_initialization_with_subsets(self):
+        """Test Ruler128K initialization with custom subsets."""
+        subsets = ["niah_single_1", "qa_1"]
+        ruler128k = Ruler128K(subsets_to_run=subsets)
+        assert ruler128k.subsets_to_run == subsets
+
+    def test_ruler128k_dataset_list_complete(self):
+        """Test that Ruler128K has all expected datasets."""
+        ruler128k = Ruler128K()
+
+        expected_datasets = [
+            "cwe",
+            "fwe",
+            "niah_multikey_1",
+            "niah_multikey_2",
+            "niah_multikey_3",
+            "niah_multiquery",
+            "niah_multivalue",
+            "niah_single_1",
+            "niah_single_2",
+            "niah_single_3",
+            "qa_1",
+            "qa_2",
+            "vt",
+        ]
+
+        for dataset in expected_datasets:
+            assert dataset in ruler128k.all_datasets
+
+        # Verify exact count
+        assert len(ruler128k.all_datasets) == len(expected_datasets)
+
+    def test_ruler128k_dataset_categories(self):
+        """Test that Ruler128K datasets contain expected categories."""
+        ruler128k = Ruler128K()
+
+        # Check for different task categories
+        niah_tasks = [d for d in ruler128k.all_datasets if d.startswith("niah_")]
+        qa_tasks = [d for d in ruler128k.all_datasets if d.startswith("qa_")]
+        other_tasks = [
+            d for d in ruler128k.all_datasets if not d.startswith(("niah_", "qa_"))
+        ]
+
+        assert (
+            len(niah_tasks) == 8
+        )  # 3 single + 3 multikey + 1 multiquery + 1 multivalue
+        assert len(qa_tasks) == 2  # qa_1, qa_2
+        assert len(other_tasks) == 3  # cwe, fwe, vt
+
+    def test_ruler128k_subset_selection_valid(self):
+        """Test Ruler128K subset selection with valid datasets."""
+        # Test with NIAH tasks
+        ruler128k = Ruler128K(subsets_to_run=["niah_single_1", "niah_multikey_1"])
+        assert ruler128k.subsets_to_run == ["niah_single_1", "niah_multikey_1"]
+
+        # Test with QA tasks
+        ruler128k = Ruler128K(subsets_to_run=["qa_1", "qa_2"])
+        assert ruler128k.subsets_to_run == ["qa_1", "qa_2"]
+
+        # Test with other tasks
+        ruler128k = Ruler128K(subsets_to_run=["cwe", "fwe", "vt"])
+        assert ruler128k.subsets_to_run == ["cwe", "fwe", "vt"]
+
+    def test_ruler128k_subset_selection_invalid(self):
+        """Test Ruler128K subset selection with invalid datasets."""
+        with pytest.raises(ValueError, match="Invalid subsets"):
+            Ruler128K(subsets_to_run=["invalid_dataset"])
+
+        with pytest.raises(ValueError, match="Invalid subsets"):
+            Ruler128K(subsets_to_run=["niah_single_1", "invalid_dataset"])
+
+        with pytest.raises(ValueError, match="Invalid subsets"):
+            Ruler128K(subsets_to_run=["ruler32k_niah_single_1"])  # wrong context length
+
+    @patch("datasets.load_dataset")
+    def test_ruler128k_load_datasets_success(self, mock_load_dataset):
+        """Test successful dataset loading."""
+        mock_load_dataset.side_effect = [
+            _mock_dataset("niah_single_1", n_rows=2),
+            _mock_dataset("qa_1", n_rows=1),
+        ]
+
+        ruler128k = Ruler128K(subsets_to_run=["niah_single_1", "qa_1"])
+        df = ruler128k._load_datasets()
+
+        # Check that datasets were loaded correctly
+        assert len(df) == 3  # 2 + 1 samples
+        assert "context_length" in df.columns
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+
+        # The raw columns must not leak into the harness schema.
+        assert list(df.columns) == OUTPUT_COLUMNS
+        assert "input" not in df.columns
+        assert "index" not in df.columns
+        assert "length" not in df.columns
+
+        # Check mock calls: single "default" config, so no config-name argument.
+        assert mock_load_dataset.call_count == 2
+        mock_load_dataset.assert_any_call(DATASET_ID, split="niah_single_1")
+        mock_load_dataset.assert_any_call(DATASET_ID, split="qa_1")
+
+    @patch("datasets.load_dataset")
+    def test_ruler128k_load_datasets_reconstructs_raw_input(self, mock_load_dataset):
+        """The three split columns must rebuild the upstream `input` exactly."""
+        raw = _raw_frame("niah_single_1", n_rows=2)
+        dataset = Mock()
+        dataset.to_pandas.return_value = raw.copy()
+        mock_load_dataset.return_value = dataset
+
+        df = Ruler128K(subsets_to_run=["niah_single_1"])._load_datasets()
+
+        for original, (_, row) in zip(raw["input"], df.iterrows()):
+            assert row["context"] + row["question"] + row["answer_prefix"] == original
+
+    @patch("datasets.load_dataset")
+    def test_ruler128k_load_datasets_uses_single_default_config(
+        self, mock_load_dataset
+    ):
+        """No config-name positional arg: these repos expose one `default` config.
+
+        Passing the subset as a config name would raise
+        ``BuilderConfig 'cwe' not found`` -- but only against the real Hub, so
+        pin the call shape here.
+        """
+        mock_load_dataset.return_value = _mock_dataset("cwe", n_rows=1)
+
+        Ruler128K(subsets_to_run=["cwe"])._load_datasets()
+
+        args, kwargs = mock_load_dataset.call_args
+        assert args == (DATASET_ID,)
+        assert kwargs == {"split": "cwe"}
+
+    @patch("datasets.load_dataset")
+    def test_ruler128k_load_datasets_partial_failure(self, mock_load_dataset):
+        """Test dataset loading with some failures."""
+        mock_load_dataset.side_effect = [
+            _mock_dataset("niah_single_1", n_rows=1),
+            Exception("Dataset not found"),
+        ]
+
+        # Use valid subsets, but mock one to fail during loading
+        ruler128k = Ruler128K(subsets_to_run=["niah_single_1", "qa_1"])
+        df = ruler128k._load_datasets()
+
+        # Should succeed with partial data (only niah_single_1 loaded)
+        assert len(df) == 1
+        assert "context_length" in df.columns
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+
+    @patch("datasets.load_dataset")
+    def test_ruler128k_load_datasets_complete_failure(self, mock_load_dataset):
+        """Test dataset loading with complete failure."""
+        mock_load_dataset.side_effect = Exception("No datasets found")
+
+        ruler128k = Ruler128K(subsets_to_run=["niah_single_1"])
+
+        with pytest.raises(
+            Exception, match="No Ruler subsets could be loaded successfully"
+        ):
+            ruler128k._load_datasets()
+
+    def test_ruler128k_post_run_evaluate_empty_results(self):
+        """Test Ruler128K evaluation with empty results."""
+        ruler128k = Ruler128K()
+        empty_df = pd.DataFrame()
+
+        results = ruler128k.post_run_evaluate(empty_df)
+        assert "error" in results
+        assert results["error"] == "No results to evaluate"
+
+    def test_ruler128k_post_run_evaluate_with_results(self):
+        """Test Ruler128K evaluation with valid results."""
+        ruler128k = Ruler128K()
+
+        # Mock results DataFrame
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "niah_single_1", "qa_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2", "Answer 3", "Answer 4"],
+                "answer": [["Truth 1"], ["Truth 2"], ["Truth 3"], ["Truth 4"]],
+                "context_length": [CONTEXT_LENGTH] * 4,
+            }
+        )
+
+        with patch("benchmark.ruler128k.ruler128k.calculate_metrics") as mock_calc:
+            # Mock different scores for different tasks
+            mock_calc.side_effect = [
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"string_match": 90.0},
+                },  # first call
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"string_match": 90.0},
+                },  # second call for context length
+            ]
+
+            results = ruler128k.post_run_evaluate(mock_results)
+
+        # Check structure
+        assert "overall_score" in results
+        assert "task_scores" in results
+        assert "context_length_scores" in results
+        assert "summary" in results
+
+        # Check overall score (average of 85.0 and 90.0)
+        expected_avg = round((85.0 + 90.0) / 2, 2)
+        assert results["overall_score"] == expected_avg
+
+        # Check context length scores
+        assert str(CONTEXT_LENGTH) in results["context_length_scores"]
+        assert results["context_length_scores"][str(CONTEXT_LENGTH)] == expected_avg
+
+        # Check summary
+        assert results["summary"]["total_tasks"] == 2
+        assert results["summary"]["total_samples"] == 4
+        assert results["summary"]["context_lengths"] == [str(CONTEXT_LENGTH)]
+
+    def test_ruler128k_post_run_evaluate_different_task_types(self):
+        """Test Ruler128K evaluation with different task types (QA vs others)."""
+        ruler128k = Ruler128K()
+
+        # Mock results with QA and non-QA tasks
+        mock_results = pd.DataFrame(
+            {
+                "task": ["qa_1", "qa_1", "niah_single_1", "cwe"],
+                "predicted_answer": [
+                    "QA Answer 1",
+                    "QA Answer 2",
+                    "NIAH Answer",
+                    "CWE Answer",
+                ],
+                "answer": [
+                    ["QA Truth 1"],
+                    ["QA Truth 2"],
+                    ["NIAH Truth"],
+                    ["CWE Truth"],
+                ],
+                "context_length": [CONTEXT_LENGTH] * 4,
+            }
+        )
+
+        with patch("benchmark.ruler128k.ruler128k.calculate_metrics") as mock_calc:
+            mock_calc.side_effect = [
+                {
+                    "qa_1": {"string_match": 80.0},
+                    "niah_single_1": {"string_match": 75.0},
+                    "cwe": {"string_match": 85.0},
+                },
+                {
+                    "qa_1": {"string_match": 80.0},
+                    "niah_single_1": {"string_match": 75.0},
+                    "cwe": {"string_match": 85.0},
+                },
+            ]
+
+            results = ruler128k.post_run_evaluate(mock_results)
+
+        # Check that all task types are included
+        assert "qa_1" in results["task_scores"]
+        assert "niah_single_1" in results["task_scores"]
+        assert "cwe" in results["task_scores"]
+
+        # Check overall score includes all tasks
+        expected_avg = round((80.0 + 75.0 + 85.0) / 3, 2)
+        assert results["overall_score"] == expected_avg
+
+    def test_ruler128k_post_run_evaluate_no_context_length(self):
+        """Test evaluation when context_length column is missing."""
+        ruler128k = Ruler128K()
+
+        # Mock results without context_length column
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2"],
+                "answer": [["Truth 1"], ["Truth 2"]],
+            }
+        )
+
+        with patch("benchmark.ruler128k.ruler128k.calculate_metrics") as mock_calc:
+            mock_calc.return_value = {
+                "niah_single_1": {"string_match": 85.0},
+                "qa_1": {"string_match": 90.0},
+            }
+
+            results = ruler128k.post_run_evaluate(mock_results)
+
+        # Should still work but without context_length_scores
+        assert "overall_score" in results
+        assert "task_scores" in results
+        assert results["context_length_scores"] == {}
+        assert results["summary"]["context_lengths"] == []
+
+    def test_ruler128k_post_run_evaluate_error_handling(self):
+        """Test error handling during evaluation."""
+        ruler128k = Ruler128K()
+
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2"],
+                "answer": [["Truth 1"], ["Truth 2"]],
+                "context_length": [CONTEXT_LENGTH, CONTEXT_LENGTH],
+            }
+        )
+
+        with patch("benchmark.ruler128k.ruler128k.calculate_metrics") as mock_calc:
+            # First call succeeds, second call (for context length) fails
+            successful_result = {
+                "niah_single_1": {"string_match": 85.0},
+                "qa_1": {"string_match": 90.0},
+            }
+            mock_calc.side_effect = [successful_result, Exception("Evaluation failed")]
+
+            results = ruler128k.post_run_evaluate(mock_results)
+
+        # Should handle errors gracefully
+        assert "overall_score" in results
+        assert "task_scores" in results
+
+        # Should still compute overall score from successful first call
+        expected_avg = round((85.0 + 90.0) / 2, 2)
+        assert results["overall_score"] == expected_avg
+
+        # Context length scores should be empty due to the error
+        assert results["context_length_scores"] == {}
+
+    def test_ruler128k_post_run_evaluate_missing_string_match(self):
+        """Test evaluation when string_match key is missing from some results."""
+        ruler128k = Ruler128K()
+
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2"],
+                "answer": [["Truth 1"], ["Truth 2"]],
+                "context_length": [CONTEXT_LENGTH, CONTEXT_LENGTH],
+            }
+        )
+
+        with patch("benchmark.ruler128k.ruler128k.calculate_metrics") as mock_calc:
+            # Return results where one task is missing string_match
+            mock_calc.side_effect = [
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"other_metric": 90.0},  # Missing string_match
+                },
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"other_metric": 90.0},
+                },
+            ]
+
+            results = ruler128k.post_run_evaluate(mock_results)
+
+        # Should only include tasks with string_match in overall score
+        assert results["overall_score"] == 85.0  # Only niah_single_1 score
+
+    @patch("datasets.load_dataset")
+    def test_ruler128k_context_length_specific(self, mock_load_dataset):
+        """Test that Ruler128K specifically uses 131072 context length."""
+        mock_load_dataset.return_value = _mock_dataset("niah_single_1", n_rows=1)
+
+        df = Ruler128K(subsets_to_run=["niah_single_1"])._load_datasets()
+
+        # Verify context length is specifically 131072 (not 32768 or others)
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+        assert not any(df["context_length"] == 32768)
+
+    def test_ruler128k_vs_ruler32k_differences(self):
+        """Test that Ruler128K has distinct properties from Ruler32K."""
+        ruler128k = Ruler128K()
+
+        # Different dataset ID
+        assert ruler128k.huggingface_dataset_id == DATASET_ID
+        assert ruler128k.huggingface_dataset_id != "xAlg-AI/att-hub-ruler-32k"
+
+        # Different benchmark name
+        assert ruler128k.benchmark_name == "ruler128k"
+        assert ruler128k.benchmark_name != "ruler32k"
+
+        # Same dataset list (should be identical for all context lengths)
+        expected_datasets = [
+            "cwe",
+            "fwe",
+            "niah_multikey_1",
+            "niah_multikey_2",
+            "niah_multikey_3",
+            "niah_multiquery",
+            "niah_multivalue",
+            "niah_single_1",
+            "niah_single_2",
+            "niah_single_3",
+            "qa_1",
+            "qa_2",
+            "vt",
+        ]
+        assert ruler128k.all_datasets == expected_datasets
+
+    def test_ruler128k_inheritance(self):
+        """Test that Ruler128K properly inherits from Benchmark."""
+        from benchmark.base import Benchmark
+
+        ruler128k = Ruler128K()
+        assert isinstance(ruler128k, Benchmark)
+
+        # Should have all required Benchmark methods
+        assert hasattr(ruler128k, "_load_datasets")
+        assert hasattr(ruler128k, "post_run_evaluate")
+        assert hasattr(ruler128k, "get_available_datasets")
+        assert hasattr(ruler128k, "_validate_subsets")
+
+    def test_ruler128k_registry_integration(self):
+        """Test that Ruler128K is properly registered in the benchmark registry."""
+        from benchmark.benchmark_registry import get_registered_benchmarks
+
+        registered = get_registered_benchmarks()
+        assert "ruler128k" in registered
+        assert registered["ruler128k"] == Ruler128K
+
+
+class TestRuler128KPrepareDataframe:
+    """Tests for the load-time split of the raw upstream `input` column."""
+
+    @pytest.mark.parametrize("family", sorted(_TEMPLATES))
+    def test_split_round_trip(self, family):
+        """context + question + answer_prefix must rebuild the input exactly."""
+        raw = _raw_input(family)
+        context, question, answer_prefix = split_context_question(raw, family)
+
+        assert context + question + answer_prefix == raw
+        assert context and question and answer_prefix
+
+    @pytest.mark.parametrize("family", sorted(_TEMPLATES))
+    def test_split_question_anchor_is_in_question_not_context(self, family):
+        """The trailing question must not survive inside the compressed context."""
+        from benchmark.ruler128k.prepare_dataframe import (
+            ANSWER_PATTERNS,
+            QUESTION_PATTERNS,
+        )
+
+        _, question, answer_prefix = split_context_question(_raw_input(family), family)
+        assert QUESTION_PATTERNS[family].search(question) is not None
+        assert ANSWER_PATTERNS[family].match(answer_prefix) is not None
+
+    @pytest.mark.parametrize("family", _REPEATED_ANCHOR_FAMILIES)
+    def test_split_uses_last_question_anchor(self, family):
+        """cwe/qa state their instruction twice; the LAST one is the boundary.
+
+        A first-match regression would move the whole haystack into `question`
+        and leave a two-sentence context -- plausible-looking, and wrong.
+        """
+        from benchmark.ruler128k.prepare_dataframe import QUESTION_PATTERNS
+
+        raw = _raw_input(family)
+        assert len(list(QUESTION_PATTERNS[family].finditer(raw))) == 2
+
+        context, question, _ = split_context_question(raw, family)
+        # The preamble occurrence stays in the context...
+        assert QUESTION_PATTERNS[family].search(context) is not None
+        # ...and the haystack does not leak into the question.
+        assert "HAYSTACK" in context
+        assert "HAYSTACK" not in question
+
+    def test_split_missing_question_anchor_raises(self):
+        """A missing question anchor raises RulerSplitError, not IndexError."""
+        with pytest.raises(RulerSplitError, match="question anchor"):
+            split_context_question("no anchors here at all", "niah_single_1")
+
+    def test_split_missing_answer_anchor_raises(self):
+        """A missing answer anchor raises RulerSplitError, not AttributeError."""
+        truncated = "What is the special magic number for pale-cactus?"
+        with pytest.raises(RulerSplitError, match="answer anchor"):
+            split_context_question(truncated, "niah_single_1")
+
+    @pytest.mark.parametrize(
+        "task,family",
+        [
+            ("niah_multikey_2", "niah"),
+            ("vt", "vt"),
+            ("cwe", "cwe"),
+            ("fwe", "fwe"),
+            ("qa_1", "qa"),
+        ],
+    )
+    def test_prepare_dataframe_schema_and_max_new_tokens(self, task, family):
+        """Output schema, task stamping and per-family generation budgets."""
+        df = prepare_dataframe(_raw_frame(task), task, CONTEXT_LENGTH)
+
+        assert list(df.columns) == OUTPUT_COLUMNS
+        assert all(df["task"] == task)
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+        assert all(df["max_new_tokens"] == MAX_NEW_TOKENS[family])
+
+    def test_prepare_dataframe_max_new_tokens_values(self):
+        """The generation budgets match RULER's own constants."""
+        assert MAX_NEW_TOKENS == {
+            "niah": 128,
+            "vt": 30,
+            "cwe": 120,
+            "fwe": 50,
+            "qa": 32,
+        }
+
+    def test_prepare_dataframe_answer_reaches_calculate_metrics(self):
+        """`outputs` arrives as an object ndarray; the metric must accept it."""
+        df = prepare_dataframe(_raw_frame("vt"), "vt", CONTEXT_LENGTH)
+        assert isinstance(df["answer"].iloc[0], np.ndarray)
+
+        df["predicted_answer"] = ["the gold answer", "nothing useful"]
+        scores = calculate_metrics(df)
+        assert scores["vt"]["string_match"] == pytest.approx(50.0)
+
+    def test_prepare_dataframe_empty_input(self):
+        """An empty raw frame yields an empty typed frame, not a TypeError."""
+        empty = pd.DataFrame(columns=["index", "input", "outputs", "length"])
+        df = prepare_dataframe(empty, "vt", CONTEXT_LENGTH)
+
+        assert len(df) == 0
+        assert list(df.columns) == OUTPUT_COLUMNS
+
+    def test_prepare_dataframe_row_failure_is_not_silently_dropped(self):
+        """One bad row fails the whole split rather than shrinking the sample."""
+        raw = _raw_frame("vt", n_rows=2)
+        raw.loc[1, "input"] = "this row has no anchors"
+
+        with pytest.raises(RulerSplitError):
+            prepare_dataframe(raw, "vt", CONTEXT_LENGTH)
+
+    @patch("datasets.load_dataset")
+    def test_load_datasets_reports_unsplittable_subset(self, mock_load_dataset, capsys):
+        """An unsplittable subset is skipped loudly and named in the summary."""
+        good = _mock_dataset("vt", n_rows=1)
+        bad_frame = _raw_frame("fwe", n_rows=1)
+        bad_frame.loc[0, "input"] = "this row has no anchors"
+        bad = Mock()
+        bad.to_pandas.return_value = bad_frame
+        mock_load_dataset.side_effect = [good, bad]
+
+        df = Ruler128K(subsets_to_run=["vt", "fwe"])._load_datasets()
+
+        assert set(df["task"]) == {"vt"}
+        captured = capsys.readouterr().out
+        assert "❌" in captured
+        assert "⚠️" in captured
+        assert "fwe" in captured

--- a/tests/unit/benchmark/test_ruler128k.py
+++ b/tests/unit/benchmark/test_ruler128k.py
@@ -32,9 +32,17 @@ _TEMPLATES = {
         "The special magic number for pale-cactus mentioned in the provided "
         "text is"
     ),
+    # RULER puts a fully worked one-shot example near the top of every vt
+    # prompt (char 1079 of 244718 in the real 64k data), so vt's question
+    # anchor genuinely occurs twice -- exercise the last-match rule on it.
     "vt": (
         "Memorize and track the chain(s) of variable assignment hidden in the "
         "following text.\n"
+        "{haystack}\n"
+        "Question: Find all variables that are assigned the value 64886 in the "
+        "text above."
+        "Answer: According to the chain(s) of variable assignment in the text "
+        "above, 5 variables are assigned the value 64886, they are:  SGM LJP\n"
         "{haystack}\n"
         "Question: Find all variables that are assigned the value 12345 in the "
         "text above."
@@ -71,9 +79,10 @@ _TEMPLATES = {
     ),
 }
 
-# Families whose instruction is stated twice: once as a context preamble and
-# once as the real trailing question.  The split must take the LAST occurrence.
-_REPEATED_ANCHOR_FAMILIES = ["cwe", "qa"]
+# Families whose question anchor occurs twice -- as a context preamble
+# (cwe, qa) or as a one-shot worked example (vt) -- and again as the real
+# trailing question.  The split must take the LAST occurrence.
+_REPEATED_ANCHOR_FAMILIES = ["cwe", "qa", "vt"]
 
 
 def _raw_input(family: str, haystack: str = "HAYSTACK " * 16) -> str:
@@ -559,10 +568,11 @@ class TestRuler128KPrepareDataframe:
 
     @pytest.mark.parametrize("family", _REPEATED_ANCHOR_FAMILIES)
     def test_split_uses_last_question_anchor(self, family):
-        """cwe/qa state their instruction twice; the LAST one is the boundary.
+        """cwe/qa/vt repeat the anchor; the LAST one is the boundary.
 
         A first-match regression would move the whole haystack into `question`
-        and leave a two-sentence context -- plausible-looking, and wrong.
+        and leave only the preamble (cwe/qa) or the one-shot example (vt) as
+        context -- plausible-looking, and wrong.
         """
         from benchmark.ruler128k.prepare_dataframe import QUESTION_PATTERNS
 
@@ -658,3 +668,50 @@ class TestRuler128KPrepareDataframe:
         assert "❌" in captured
         assert "⚠️" in captured
         assert "fwe" in captured
+
+
+class TestRuler128KMetricRouting:
+    """The qa-vs-everything-else metric split in calculate_metrics."""
+
+    @pytest.mark.parametrize(
+        "task,expected",
+        [
+            # string_match_part: credit for matching ANY one gold.
+            ("qa_1", 100.0),
+            ("qa_2", 100.0),
+            # string_match_all: credit for the FRACTION of golds matched.
+            ("vt", 50.0),
+            ("fwe", 50.0),
+            ("cwe", 50.0),
+            ("niah_multikey_2", 50.0),
+            ("niah_single_1", 50.0),
+        ],
+    )
+    def test_qa_uses_part_and_every_other_family_uses_all(self, task, expected):
+        """Routing is one `task.split("_")[0] == "qa"` branch -- pin both sides.
+
+        The two metrics only disagree on multi-gold rows, so a single gold
+        cannot detect a mis-route. With two golds and one hit, `part` scores
+        100 and `all` scores 50.
+        """
+        df = pd.DataFrame(
+            {
+                "task": [task],
+                "answer": [np.array(["alpha", "beta"], dtype=object)],
+                "predicted_answer": ["the answer is alpha"],
+            }
+        )
+
+        assert calculate_metrics(df)[task]["string_match"] == expected
+
+    def test_family_routing_uses_name_prefix_not_substring(self):
+        """`niah_multiquery` must not route to qa just because it ends in 'query'."""
+        df = pd.DataFrame(
+            {
+                "task": ["niah_multiquery"],
+                "answer": [np.array(["alpha", "beta"], dtype=object)],
+                "predicted_answer": ["the answer is alpha"],
+            }
+        )
+
+        assert calculate_metrics(df)["niah_multiquery"]["string_match"] == 50.0

--- a/tests/unit/benchmark/test_ruler128k.py
+++ b/tests/unit/benchmark/test_ruler128k.py
@@ -79,9 +79,9 @@ _TEMPLATES = {
     ),
 }
 
-# Families whose question anchor occurs twice -- as a context preamble
-# (cwe, qa) or as a one-shot worked example (vt) -- and again as the real
-# trailing question.  The split must take the LAST occurrence.
+# Families whose question anchor occurs twice -- qa restates its opening
+# instruction, cwe and vt each embed a worked one-shot example -- and again as
+# the real trailing question.  The split must take the LAST occurrence.
 _REPEATED_ANCHOR_FAMILIES = ["cwe", "qa", "vt"]
 
 

--- a/tests/unit/benchmark/test_ruler64k.py
+++ b/tests/unit/benchmark/test_ruler64k.py
@@ -32,9 +32,17 @@ _TEMPLATES = {
         "The special magic number for pale-cactus mentioned in the provided "
         "text is"
     ),
+    # RULER puts a fully worked one-shot example near the top of every vt
+    # prompt (char 1079 of 244718 in the real 64k data), so vt's question
+    # anchor genuinely occurs twice -- exercise the last-match rule on it.
     "vt": (
         "Memorize and track the chain(s) of variable assignment hidden in the "
         "following text.\n"
+        "{haystack}\n"
+        "Question: Find all variables that are assigned the value 64886 in the "
+        "text above."
+        "Answer: According to the chain(s) of variable assignment in the text "
+        "above, 5 variables are assigned the value 64886, they are:  SGM LJP\n"
         "{haystack}\n"
         "Question: Find all variables that are assigned the value 12345 in the "
         "text above."
@@ -71,9 +79,10 @@ _TEMPLATES = {
     ),
 }
 
-# Families whose instruction is stated twice: once as a context preamble and
-# once as the real trailing question.  The split must take the LAST occurrence.
-_REPEATED_ANCHOR_FAMILIES = ["cwe", "qa"]
+# Families whose question anchor occurs twice -- as a context preamble
+# (cwe, qa) or as a one-shot worked example (vt) -- and again as the real
+# trailing question.  The split must take the LAST occurrence.
+_REPEATED_ANCHOR_FAMILIES = ["cwe", "qa", "vt"]
 
 
 def _raw_input(family: str, haystack: str = "HAYSTACK " * 16) -> str:
@@ -557,10 +566,11 @@ class TestRuler64KPrepareDataframe:
 
     @pytest.mark.parametrize("family", _REPEATED_ANCHOR_FAMILIES)
     def test_split_uses_last_question_anchor(self, family):
-        """cwe/qa state their instruction twice; the LAST one is the boundary.
+        """cwe/qa/vt repeat the anchor; the LAST one is the boundary.
 
         A first-match regression would move the whole haystack into `question`
-        and leave a two-sentence context -- plausible-looking, and wrong.
+        and leave only the preamble (cwe/qa) or the one-shot example (vt) as
+        context -- plausible-looking, and wrong.
         """
         from benchmark.ruler64k.prepare_dataframe import QUESTION_PATTERNS
 
@@ -656,3 +666,50 @@ class TestRuler64KPrepareDataframe:
         assert "❌" in captured
         assert "⚠️" in captured
         assert "fwe" in captured
+
+
+class TestRuler64KMetricRouting:
+    """The qa-vs-everything-else metric split in calculate_metrics."""
+
+    @pytest.mark.parametrize(
+        "task,expected",
+        [
+            # string_match_part: credit for matching ANY one gold.
+            ("qa_1", 100.0),
+            ("qa_2", 100.0),
+            # string_match_all: credit for the FRACTION of golds matched.
+            ("vt", 50.0),
+            ("fwe", 50.0),
+            ("cwe", 50.0),
+            ("niah_multikey_2", 50.0),
+            ("niah_single_1", 50.0),
+        ],
+    )
+    def test_qa_uses_part_and_every_other_family_uses_all(self, task, expected):
+        """Routing is one `task.split("_")[0] == "qa"` branch -- pin both sides.
+
+        The two metrics only disagree on multi-gold rows, so a single gold
+        cannot detect a mis-route. With two golds and one hit, `part` scores
+        100 and `all` scores 50.
+        """
+        df = pd.DataFrame(
+            {
+                "task": [task],
+                "answer": [np.array(["alpha", "beta"], dtype=object)],
+                "predicted_answer": ["the answer is alpha"],
+            }
+        )
+
+        assert calculate_metrics(df)[task]["string_match"] == expected
+
+    def test_family_routing_uses_name_prefix_not_substring(self):
+        """`niah_multiquery` must not route to qa just because it ends in 'query'."""
+        df = pd.DataFrame(
+            {
+                "task": ["niah_multiquery"],
+                "answer": [np.array(["alpha", "beta"], dtype=object)],
+                "predicted_answer": ["the answer is alpha"],
+            }
+        )
+
+        assert calculate_metrics(df)["niah_multiquery"]["string_match"] == 50.0

--- a/tests/unit/benchmark/test_ruler64k.py
+++ b/tests/unit/benchmark/test_ruler64k.py
@@ -79,9 +79,9 @@ _TEMPLATES = {
     ),
 }
 
-# Families whose question anchor occurs twice -- as a context preamble
-# (cwe, qa) or as a one-shot worked example (vt) -- and again as the real
-# trailing question.  The split must take the LAST occurrence.
+# Families whose question anchor occurs twice -- qa restates its opening
+# instruction, cwe and vt each embed a worked one-shot example -- and again as
+# the real trailing question.  The split must take the LAST occurrence.
 _REPEATED_ANCHOR_FAMILIES = ["cwe", "qa", "vt"]
 
 

--- a/tests/unit/benchmark/test_ruler64k.py
+++ b/tests/unit/benchmark/test_ruler64k.py
@@ -1,0 +1,658 @@
+"""Unit tests for Ruler64K benchmark implementation."""
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmark.ruler64k import Ruler64K
+from benchmark.ruler64k.calculate_metrics import calculate_metrics
+from benchmark.ruler64k.prepare_dataframe import (
+    MAX_NEW_TOKENS,
+    OUTPUT_COLUMNS,
+    RulerSplitError,
+    prepare_dataframe,
+    split_context_question,
+)
+
+DATASET_ID = "SaylorTwift/RULER-65536-llama-3.2-tokenizer"
+CONTEXT_LENGTH = 65536
+
+# Minimal stand-ins for the five RULER prompt families.  Each is
+# "<preamble><haystack><question><answer_prefix>" exactly as RULER emits it, so
+# split_context_question has something realistic to cut.
+_TEMPLATES = {
+    "niah": (
+        "One of the special magic numbers for pale-cactus is hidden in the "
+        "following text. Make sure to memorize it.\n"
+        "{haystack}\n"
+        "What is the special magic number for pale-cactus mentioned in the "
+        "provided text? "
+        "The special magic number for pale-cactus mentioned in the provided "
+        "text is"
+    ),
+    "vt": (
+        "Memorize and track the chain(s) of variable assignment hidden in the "
+        "following text.\n"
+        "{haystack}\n"
+        "Question: Find all variables that are assigned the value 12345 in the "
+        "text above."
+        "Answer: According to the chain(s) of variable assignment in the text "
+        "above, 5 variables are assigned the value 12345, they are: "
+    ),
+    "cwe": (
+        "Below is a numbered list of words. In these words, some appear more "
+        "often than others. Memorize the ones that appear most often.\n"
+        "Question: What are the 10 most common words in the above list?\n"
+        "{haystack}\n"
+        "Question: What are the 10 most common words in the above list? "
+        "Answer: The top 10 words that appear most often in the list are:"
+    ),
+    "fwe": (
+        "Read the following coded text and track the frequency of each coded "
+        "word.\n"
+        "{haystack}\n"
+        "Question: Do not provide any explanation. Please ignore the dots "
+        "'....'. What are the three most frequently appeared words in the "
+        "above coded text? "
+        "Answer: According to the coded text above, the three most frequently "
+        "appeared words are:"
+    ),
+    "qa": (
+        "Answer the question based on the given documents. Only give me the "
+        "answer and do not output any other words.\n\n"
+        "The following are given documents.\n\n"
+        "{haystack}\n\n"
+        "Answer the question based on the given documents. Only give me the "
+        "answer and do not output any other words.\n\n"
+        "Question: What colour is the sky? "
+        "Answer:"
+    ),
+}
+
+# Families whose instruction is stated twice: once as a context preamble and
+# once as the real trailing question.  The split must take the LAST occurrence.
+_REPEATED_ANCHOR_FAMILIES = ["cwe", "qa"]
+
+
+def _raw_input(family: str, haystack: str = "HAYSTACK " * 16) -> str:
+    """Build a synthetic raw RULER sample for one prompt family."""
+    return _TEMPLATES[family].format(haystack=haystack)
+
+
+def _raw_frame(task: str, n_rows: int = 2) -> pd.DataFrame:
+    """Build a raw upstream frame (index / input / outputs / length)."""
+    family = task.split("_")[0]
+    return pd.DataFrame(
+        {
+            "index": list(range(n_rows)),
+            "input": [_raw_input(family) for _ in range(n_rows)],
+            "outputs": [np.array(["gold"], dtype=object) for _ in range(n_rows)],
+            "length": [CONTEXT_LENGTH] * n_rows,
+        }
+    )
+
+
+def _mock_dataset(task: str, n_rows: int = 2) -> Mock:
+    """A Mock standing in for a loaded HuggingFace split."""
+    dataset = Mock()
+    dataset.to_pandas.return_value = _raw_frame(task, n_rows)
+    return dataset
+
+
+class TestRuler64KUnit:
+    """Unit tests for Ruler64K class."""
+
+    def test_ruler64k_initialization(self):
+        """Test Ruler64K initialization."""
+        ruler64k = Ruler64K()
+        assert len(ruler64k.all_datasets) == 13
+        assert ruler64k.benchmark_name == "ruler64k"
+        assert ruler64k.huggingface_dataset_id == DATASET_ID
+
+    def test_ruler64k_initialization_with_subsets(self):
+        """Test Ruler64K initialization with custom subsets."""
+        subsets = ["niah_single_1", "qa_1"]
+        ruler64k = Ruler64K(subsets_to_run=subsets)
+        assert ruler64k.subsets_to_run == subsets
+
+    def test_ruler64k_dataset_list_complete(self):
+        """Test that Ruler64K has all expected datasets."""
+        ruler64k = Ruler64K()
+
+        expected_datasets = [
+            "cwe",
+            "fwe",
+            "niah_multikey_1",
+            "niah_multikey_2",
+            "niah_multikey_3",
+            "niah_multiquery",
+            "niah_multivalue",
+            "niah_single_1",
+            "niah_single_2",
+            "niah_single_3",
+            "qa_1",
+            "qa_2",
+            "vt",
+        ]
+
+        for dataset in expected_datasets:
+            assert dataset in ruler64k.all_datasets
+
+        # Verify exact count
+        assert len(ruler64k.all_datasets) == len(expected_datasets)
+
+    def test_ruler64k_dataset_categories(self):
+        """Test that Ruler64K datasets contain expected categories."""
+        ruler64k = Ruler64K()
+
+        # Check for different task categories
+        niah_tasks = [d for d in ruler64k.all_datasets if d.startswith("niah_")]
+        qa_tasks = [d for d in ruler64k.all_datasets if d.startswith("qa_")]
+        other_tasks = [
+            d for d in ruler64k.all_datasets if not d.startswith(("niah_", "qa_"))
+        ]
+
+        assert (
+            len(niah_tasks) == 8
+        )  # 3 single + 3 multikey + 1 multiquery + 1 multivalue
+        assert len(qa_tasks) == 2  # qa_1, qa_2
+        assert len(other_tasks) == 3  # cwe, fwe, vt
+
+    def test_ruler64k_subset_selection_valid(self):
+        """Test Ruler64K subset selection with valid datasets."""
+        # Test with NIAH tasks
+        ruler64k = Ruler64K(subsets_to_run=["niah_single_1", "niah_multikey_1"])
+        assert ruler64k.subsets_to_run == ["niah_single_1", "niah_multikey_1"]
+
+        # Test with QA tasks
+        ruler64k = Ruler64K(subsets_to_run=["qa_1", "qa_2"])
+        assert ruler64k.subsets_to_run == ["qa_1", "qa_2"]
+
+        # Test with other tasks
+        ruler64k = Ruler64K(subsets_to_run=["cwe", "fwe", "vt"])
+        assert ruler64k.subsets_to_run == ["cwe", "fwe", "vt"]
+
+    def test_ruler64k_subset_selection_invalid(self):
+        """Test Ruler64K subset selection with invalid datasets."""
+        with pytest.raises(ValueError, match="Invalid subsets"):
+            Ruler64K(subsets_to_run=["invalid_dataset"])
+
+        with pytest.raises(ValueError, match="Invalid subsets"):
+            Ruler64K(subsets_to_run=["niah_single_1", "invalid_dataset"])
+
+        with pytest.raises(ValueError, match="Invalid subsets"):
+            Ruler64K(subsets_to_run=["ruler32k_niah_single_1"])  # wrong context length
+
+    @patch("datasets.load_dataset")
+    def test_ruler64k_load_datasets_success(self, mock_load_dataset):
+        """Test successful dataset loading."""
+        mock_load_dataset.side_effect = [
+            _mock_dataset("niah_single_1", n_rows=2),
+            _mock_dataset("qa_1", n_rows=1),
+        ]
+
+        ruler64k = Ruler64K(subsets_to_run=["niah_single_1", "qa_1"])
+        df = ruler64k._load_datasets()
+
+        # Check that datasets were loaded correctly
+        assert len(df) == 3  # 2 + 1 samples
+        assert "context_length" in df.columns
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+
+        # The raw columns must not leak into the harness schema.
+        assert list(df.columns) == OUTPUT_COLUMNS
+        assert "input" not in df.columns
+        assert "index" not in df.columns
+        assert "length" not in df.columns
+
+        # Check mock calls: single "default" config, so no config-name argument.
+        assert mock_load_dataset.call_count == 2
+        mock_load_dataset.assert_any_call(DATASET_ID, split="niah_single_1")
+        mock_load_dataset.assert_any_call(DATASET_ID, split="qa_1")
+
+    @patch("datasets.load_dataset")
+    def test_ruler64k_load_datasets_reconstructs_raw_input(self, mock_load_dataset):
+        """The three split columns must rebuild the upstream `input` exactly."""
+        raw = _raw_frame("niah_single_1", n_rows=2)
+        dataset = Mock()
+        dataset.to_pandas.return_value = raw.copy()
+        mock_load_dataset.return_value = dataset
+
+        df = Ruler64K(subsets_to_run=["niah_single_1"])._load_datasets()
+
+        for original, (_, row) in zip(raw["input"], df.iterrows()):
+            assert row["context"] + row["question"] + row["answer_prefix"] == original
+
+    @patch("datasets.load_dataset")
+    def test_ruler64k_load_datasets_uses_single_default_config(self, mock_load_dataset):
+        """No config-name positional arg: these repos expose one `default` config.
+
+        Passing the subset as a config name would raise
+        ``BuilderConfig 'cwe' not found`` -- but only against the real Hub, so
+        pin the call shape here.
+        """
+        mock_load_dataset.return_value = _mock_dataset("cwe", n_rows=1)
+
+        Ruler64K(subsets_to_run=["cwe"])._load_datasets()
+
+        args, kwargs = mock_load_dataset.call_args
+        assert args == (DATASET_ID,)
+        assert kwargs == {"split": "cwe"}
+
+    @patch("datasets.load_dataset")
+    def test_ruler64k_load_datasets_partial_failure(self, mock_load_dataset):
+        """Test dataset loading with some failures."""
+        mock_load_dataset.side_effect = [
+            _mock_dataset("niah_single_1", n_rows=1),
+            Exception("Dataset not found"),
+        ]
+
+        # Use valid subsets, but mock one to fail during loading
+        ruler64k = Ruler64K(subsets_to_run=["niah_single_1", "qa_1"])
+        df = ruler64k._load_datasets()
+
+        # Should succeed with partial data (only niah_single_1 loaded)
+        assert len(df) == 1
+        assert "context_length" in df.columns
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+
+    @patch("datasets.load_dataset")
+    def test_ruler64k_load_datasets_complete_failure(self, mock_load_dataset):
+        """Test dataset loading with complete failure."""
+        mock_load_dataset.side_effect = Exception("No datasets found")
+
+        ruler64k = Ruler64K(subsets_to_run=["niah_single_1"])
+
+        with pytest.raises(
+            Exception, match="No Ruler subsets could be loaded successfully"
+        ):
+            ruler64k._load_datasets()
+
+    def test_ruler64k_post_run_evaluate_empty_results(self):
+        """Test Ruler64K evaluation with empty results."""
+        ruler64k = Ruler64K()
+        empty_df = pd.DataFrame()
+
+        results = ruler64k.post_run_evaluate(empty_df)
+        assert "error" in results
+        assert results["error"] == "No results to evaluate"
+
+    def test_ruler64k_post_run_evaluate_with_results(self):
+        """Test Ruler64K evaluation with valid results."""
+        ruler64k = Ruler64K()
+
+        # Mock results DataFrame
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "niah_single_1", "qa_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2", "Answer 3", "Answer 4"],
+                "answer": [["Truth 1"], ["Truth 2"], ["Truth 3"], ["Truth 4"]],
+                "context_length": [CONTEXT_LENGTH] * 4,
+            }
+        )
+
+        with patch("benchmark.ruler64k.ruler64k.calculate_metrics") as mock_calc:
+            # Mock different scores for different tasks
+            mock_calc.side_effect = [
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"string_match": 90.0},
+                },  # first call
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"string_match": 90.0},
+                },  # second call for context length
+            ]
+
+            results = ruler64k.post_run_evaluate(mock_results)
+
+        # Check structure
+        assert "overall_score" in results
+        assert "task_scores" in results
+        assert "context_length_scores" in results
+        assert "summary" in results
+
+        # Check overall score (average of 85.0 and 90.0)
+        expected_avg = round((85.0 + 90.0) / 2, 2)
+        assert results["overall_score"] == expected_avg
+
+        # Check context length scores
+        assert str(CONTEXT_LENGTH) in results["context_length_scores"]
+        assert results["context_length_scores"][str(CONTEXT_LENGTH)] == expected_avg
+
+        # Check summary
+        assert results["summary"]["total_tasks"] == 2
+        assert results["summary"]["total_samples"] == 4
+        assert results["summary"]["context_lengths"] == [str(CONTEXT_LENGTH)]
+
+    def test_ruler64k_post_run_evaluate_different_task_types(self):
+        """Test Ruler64K evaluation with different task types (QA vs others)."""
+        ruler64k = Ruler64K()
+
+        # Mock results with QA and non-QA tasks
+        mock_results = pd.DataFrame(
+            {
+                "task": ["qa_1", "qa_1", "niah_single_1", "cwe"],
+                "predicted_answer": [
+                    "QA Answer 1",
+                    "QA Answer 2",
+                    "NIAH Answer",
+                    "CWE Answer",
+                ],
+                "answer": [
+                    ["QA Truth 1"],
+                    ["QA Truth 2"],
+                    ["NIAH Truth"],
+                    ["CWE Truth"],
+                ],
+                "context_length": [CONTEXT_LENGTH] * 4,
+            }
+        )
+
+        with patch("benchmark.ruler64k.ruler64k.calculate_metrics") as mock_calc:
+            mock_calc.side_effect = [
+                {
+                    "qa_1": {"string_match": 80.0},
+                    "niah_single_1": {"string_match": 75.0},
+                    "cwe": {"string_match": 85.0},
+                },
+                {
+                    "qa_1": {"string_match": 80.0},
+                    "niah_single_1": {"string_match": 75.0},
+                    "cwe": {"string_match": 85.0},
+                },
+            ]
+
+            results = ruler64k.post_run_evaluate(mock_results)
+
+        # Check that all task types are included
+        assert "qa_1" in results["task_scores"]
+        assert "niah_single_1" in results["task_scores"]
+        assert "cwe" in results["task_scores"]
+
+        # Check overall score includes all tasks
+        expected_avg = round((80.0 + 75.0 + 85.0) / 3, 2)
+        assert results["overall_score"] == expected_avg
+
+    def test_ruler64k_post_run_evaluate_no_context_length(self):
+        """Test evaluation when context_length column is missing."""
+        ruler64k = Ruler64K()
+
+        # Mock results without context_length column
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2"],
+                "answer": [["Truth 1"], ["Truth 2"]],
+            }
+        )
+
+        with patch("benchmark.ruler64k.ruler64k.calculate_metrics") as mock_calc:
+            mock_calc.return_value = {
+                "niah_single_1": {"string_match": 85.0},
+                "qa_1": {"string_match": 90.0},
+            }
+
+            results = ruler64k.post_run_evaluate(mock_results)
+
+        # Should still work but without context_length_scores
+        assert "overall_score" in results
+        assert "task_scores" in results
+        assert results["context_length_scores"] == {}
+        assert results["summary"]["context_lengths"] == []
+
+    def test_ruler64k_post_run_evaluate_error_handling(self):
+        """Test error handling during evaluation."""
+        ruler64k = Ruler64K()
+
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2"],
+                "answer": [["Truth 1"], ["Truth 2"]],
+                "context_length": [CONTEXT_LENGTH, CONTEXT_LENGTH],
+            }
+        )
+
+        with patch("benchmark.ruler64k.ruler64k.calculate_metrics") as mock_calc:
+            # First call succeeds, second call (for context length) fails
+            successful_result = {
+                "niah_single_1": {"string_match": 85.0},
+                "qa_1": {"string_match": 90.0},
+            }
+            mock_calc.side_effect = [successful_result, Exception("Evaluation failed")]
+
+            results = ruler64k.post_run_evaluate(mock_results)
+
+        # Should handle errors gracefully
+        assert "overall_score" in results
+        assert "task_scores" in results
+
+        # Should still compute overall score from successful first call
+        expected_avg = round((85.0 + 90.0) / 2, 2)
+        assert results["overall_score"] == expected_avg
+
+        # Context length scores should be empty due to the error
+        assert results["context_length_scores"] == {}
+
+    def test_ruler64k_post_run_evaluate_missing_string_match(self):
+        """Test evaluation when string_match key is missing from some results."""
+        ruler64k = Ruler64K()
+
+        mock_results = pd.DataFrame(
+            {
+                "task": ["niah_single_1", "qa_1"],
+                "predicted_answer": ["Answer 1", "Answer 2"],
+                "answer": [["Truth 1"], ["Truth 2"]],
+                "context_length": [CONTEXT_LENGTH, CONTEXT_LENGTH],
+            }
+        )
+
+        with patch("benchmark.ruler64k.ruler64k.calculate_metrics") as mock_calc:
+            # Return results where one task is missing string_match
+            mock_calc.side_effect = [
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"other_metric": 90.0},  # Missing string_match
+                },
+                {
+                    "niah_single_1": {"string_match": 85.0},
+                    "qa_1": {"other_metric": 90.0},
+                },
+            ]
+
+            results = ruler64k.post_run_evaluate(mock_results)
+
+        # Should only include tasks with string_match in overall score
+        assert results["overall_score"] == 85.0  # Only niah_single_1 score
+
+    @patch("datasets.load_dataset")
+    def test_ruler64k_context_length_specific(self, mock_load_dataset):
+        """Test that Ruler64K specifically uses 65536 context length."""
+        mock_load_dataset.return_value = _mock_dataset("niah_single_1", n_rows=1)
+
+        df = Ruler64K(subsets_to_run=["niah_single_1"])._load_datasets()
+
+        # Verify context length is specifically 65536 (not 32768 or others)
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+        assert not any(df["context_length"] == 32768)
+
+    def test_ruler64k_vs_ruler32k_differences(self):
+        """Test that Ruler64K has distinct properties from Ruler32K."""
+        ruler64k = Ruler64K()
+
+        # Different dataset ID
+        assert ruler64k.huggingface_dataset_id == DATASET_ID
+        assert ruler64k.huggingface_dataset_id != "xAlg-AI/att-hub-ruler-32k"
+
+        # Different benchmark name
+        assert ruler64k.benchmark_name == "ruler64k"
+        assert ruler64k.benchmark_name != "ruler32k"
+
+        # Same dataset list (should be identical for all context lengths)
+        expected_datasets = [
+            "cwe",
+            "fwe",
+            "niah_multikey_1",
+            "niah_multikey_2",
+            "niah_multikey_3",
+            "niah_multiquery",
+            "niah_multivalue",
+            "niah_single_1",
+            "niah_single_2",
+            "niah_single_3",
+            "qa_1",
+            "qa_2",
+            "vt",
+        ]
+        assert ruler64k.all_datasets == expected_datasets
+
+    def test_ruler64k_inheritance(self):
+        """Test that Ruler64K properly inherits from Benchmark."""
+        from benchmark.base import Benchmark
+
+        ruler64k = Ruler64K()
+        assert isinstance(ruler64k, Benchmark)
+
+        # Should have all required Benchmark methods
+        assert hasattr(ruler64k, "_load_datasets")
+        assert hasattr(ruler64k, "post_run_evaluate")
+        assert hasattr(ruler64k, "get_available_datasets")
+        assert hasattr(ruler64k, "_validate_subsets")
+
+    def test_ruler64k_registry_integration(self):
+        """Test that Ruler64K is properly registered in the benchmark registry."""
+        from benchmark.benchmark_registry import get_registered_benchmarks
+
+        registered = get_registered_benchmarks()
+        assert "ruler64k" in registered
+        assert registered["ruler64k"] == Ruler64K
+
+
+class TestRuler64KPrepareDataframe:
+    """Tests for the load-time split of the raw upstream `input` column."""
+
+    @pytest.mark.parametrize("family", sorted(_TEMPLATES))
+    def test_split_round_trip(self, family):
+        """context + question + answer_prefix must rebuild the input exactly."""
+        raw = _raw_input(family)
+        context, question, answer_prefix = split_context_question(raw, family)
+
+        assert context + question + answer_prefix == raw
+        assert context and question and answer_prefix
+
+    @pytest.mark.parametrize("family", sorted(_TEMPLATES))
+    def test_split_question_anchor_is_in_question_not_context(self, family):
+        """The trailing question must not survive inside the compressed context."""
+        from benchmark.ruler64k.prepare_dataframe import (
+            ANSWER_PATTERNS,
+            QUESTION_PATTERNS,
+        )
+
+        _, question, answer_prefix = split_context_question(_raw_input(family), family)
+        assert QUESTION_PATTERNS[family].search(question) is not None
+        assert ANSWER_PATTERNS[family].match(answer_prefix) is not None
+
+    @pytest.mark.parametrize("family", _REPEATED_ANCHOR_FAMILIES)
+    def test_split_uses_last_question_anchor(self, family):
+        """cwe/qa state their instruction twice; the LAST one is the boundary.
+
+        A first-match regression would move the whole haystack into `question`
+        and leave a two-sentence context -- plausible-looking, and wrong.
+        """
+        from benchmark.ruler64k.prepare_dataframe import QUESTION_PATTERNS
+
+        raw = _raw_input(family)
+        assert len(list(QUESTION_PATTERNS[family].finditer(raw))) == 2
+
+        context, question, _ = split_context_question(raw, family)
+        # The preamble occurrence stays in the context...
+        assert QUESTION_PATTERNS[family].search(context) is not None
+        # ...and the haystack does not leak into the question.
+        assert "HAYSTACK" in context
+        assert "HAYSTACK" not in question
+
+    def test_split_missing_question_anchor_raises(self):
+        """A missing question anchor raises RulerSplitError, not IndexError."""
+        with pytest.raises(RulerSplitError, match="question anchor"):
+            split_context_question("no anchors here at all", "niah_single_1")
+
+    def test_split_missing_answer_anchor_raises(self):
+        """A missing answer anchor raises RulerSplitError, not AttributeError."""
+        truncated = "What is the special magic number for pale-cactus?"
+        with pytest.raises(RulerSplitError, match="answer anchor"):
+            split_context_question(truncated, "niah_single_1")
+
+    @pytest.mark.parametrize(
+        "task,family",
+        [
+            ("niah_multikey_2", "niah"),
+            ("vt", "vt"),
+            ("cwe", "cwe"),
+            ("fwe", "fwe"),
+            ("qa_1", "qa"),
+        ],
+    )
+    def test_prepare_dataframe_schema_and_max_new_tokens(self, task, family):
+        """Output schema, task stamping and per-family generation budgets."""
+        df = prepare_dataframe(_raw_frame(task), task, CONTEXT_LENGTH)
+
+        assert list(df.columns) == OUTPUT_COLUMNS
+        assert all(df["task"] == task)
+        assert all(df["context_length"] == CONTEXT_LENGTH)
+        assert all(df["max_new_tokens"] == MAX_NEW_TOKENS[family])
+
+    def test_prepare_dataframe_max_new_tokens_values(self):
+        """The generation budgets match RULER's own constants."""
+        assert MAX_NEW_TOKENS == {
+            "niah": 128,
+            "vt": 30,
+            "cwe": 120,
+            "fwe": 50,
+            "qa": 32,
+        }
+
+    def test_prepare_dataframe_answer_reaches_calculate_metrics(self):
+        """`outputs` arrives as an object ndarray; the metric must accept it."""
+        df = prepare_dataframe(_raw_frame("vt"), "vt", CONTEXT_LENGTH)
+        assert isinstance(df["answer"].iloc[0], np.ndarray)
+
+        df["predicted_answer"] = ["the gold answer", "nothing useful"]
+        scores = calculate_metrics(df)
+        assert scores["vt"]["string_match"] == pytest.approx(50.0)
+
+    def test_prepare_dataframe_empty_input(self):
+        """An empty raw frame yields an empty typed frame, not a TypeError."""
+        empty = pd.DataFrame(columns=["index", "input", "outputs", "length"])
+        df = prepare_dataframe(empty, "vt", CONTEXT_LENGTH)
+
+        assert len(df) == 0
+        assert list(df.columns) == OUTPUT_COLUMNS
+
+    def test_prepare_dataframe_row_failure_is_not_silently_dropped(self):
+        """One bad row fails the whole split rather than shrinking the sample."""
+        raw = _raw_frame("vt", n_rows=2)
+        raw.loc[1, "input"] = "this row has no anchors"
+
+        with pytest.raises(RulerSplitError):
+            prepare_dataframe(raw, "vt", CONTEXT_LENGTH)
+
+    @patch("datasets.load_dataset")
+    def test_load_datasets_reports_unsplittable_subset(self, mock_load_dataset, capsys):
+        """An unsplittable subset is skipped loudly and named in the summary."""
+        good = _mock_dataset("vt", n_rows=1)
+        bad_frame = _raw_frame("fwe", n_rows=1)
+        bad_frame.loc[0, "input"] = "this row has no anchors"
+        bad = Mock()
+        bad.to_pandas.return_value = bad_frame
+        mock_load_dataset.side_effect = [good, bad]
+
+        df = Ruler64K(subsets_to_run=["vt", "fwe"])._load_datasets()
+
+        assert set(df["task"]) == {"vt"}
+        captured = capsys.readouterr().out
+        assert "❌" in captured
+        assert "⚠️" in captured
+        assert "fwe" in captured


### PR DESCRIPTION
Adds `ruler64k` and `ruler128k` alongside the existing `ruler16k` / `ruler32k`, so RULER can be run at 64k and 128k context — **and fixes a tokenizer defect in `ModelAdapterHF` that the 128k numbers exposed.**

## What changed since the first review

The evaluation in the original description contained a result I flagged as suspicious: at 128k, `vt` scored **49.6 dense against 70.0 for a 2%-density sparse arm**. That has now been root-caused, fixed, and re-measured. The fix is `sparse_attention_hub/adapters/huggingface.py`, two call sites, plus a regression test.

Everything else about the benchmark packages is unchanged from the first review.

## The bug

`_preprocess_context_and_questions` renders the chat template with `tokenize=False`, so the string it returns already carries the model's BOS. `process_request` then encoded that string — and the question — with `add_special_tokens` left at its default of `True`. Llama-3.x and Gemma fast tokenizers carry a `TemplateProcessing` post-processor that prepends BOS on **every** `encode()`, and it fires even though `tokenizer.add_bos_token` reads `False` — that attribute is not a usable check.

A real RULER prompt on Llama-3.1 therefore carried **three** `<|begin_of_text|>`:

| | pre-fix | post-fix |
|---|---|---|
| BOS positions, 128k `vt` row | `[0, 1, 130778]` | `[0]` |
| context ids | `[128000, 128000, 128006, 9125, …]` | `[128000, 128006, 9125, 271, …]` |
| question ids | `[128000, 14924, 25, …]` | `[14924, 25, 7531, …]` |

The third BOS sits at exactly `len(context_ids)` — the first token the model sees after a 130k-token prefill.

**The fix mirrors HuggingFace's own contract.** `apply_chat_template(tokenize=True)` tokenizes the rendered string with `add_special_tokens=False` (`tokenization_utils_base.py`), because the rendered template is expected to carry every special token already. Post-fix, the adapter reproduces `apply_chat_template(tokenize=True)` **byte-for-byte on all nine cached chat tokenizers**; pre-fix it diverged on four (Llama-3.1, gemma-3-4b-it, Ministral-8B-2410, Llama-2-7b-chat).

Context keeps `add_special_tokens=True` when there is no chat template, so base models still get their BOS. The question never adds special tokens, being a mid-sequence continuation.

**Unaffected models** (bit-identical ids before and after, verified on real RULER rows): Qwen2.5/Qwen3, Ministral-3-2512, Nemotron-3-Nano, Olmo-3. Published numbers for those stand.

## Mechanism — two channels, not one

Measured per-row on the same rows, pre-fix vs post-fix.

**1. Early stopping (`vt`).** The third BOS reads as a document-start marker before the question, so the model answers and terminates. At 128k, dense named a single variable and emitted `<|eot_id|>` on **45 of 100 rows** (0/100 at 64k), which under `string_match_all` mechanically caps the row at 1/5. Three controls establish this is a *stopping* failure, not a retrieval one:

- precision on the variables it did name stayed at **0.99** — all 45 collapsed rows named `gold[0]` correctly;
- raising `max_new_tokens` from 30 to 256 left **97/100 predictions bit-identical** (the truncation is model-emitted EOS, not the budget);
- **banning EOS closes the entire gap** — on a fixed 30-row A/B the 3-BOS prompt goes 2.53 → 3.60 golds hit (12 up, 0 down, p = 0.0005) and becomes statistically indistinguishable from the 1-BOS prompt (3.47).

**2. Wrong-needle retrieval (`niah_multikey_*`, `fwe`).** Here the answer *length* is pinned and only the answer *identity* changes: the 3-BOS model returns a different, well-formed distractor lifted from the haystack. `niah_multikey_3` @128k: 44 of 100 rows changed identity, +18.00, with zero length change.

## Why the sparse arm "won"

Pre-fix `oracle2` repeated a variable code on **27/100** rows against dense's 5/100 — the mask perturbation kept the decoder off `<|eot_id|>` long enough to enumerate, buying partial credit it had not earned. It collapsed on 8 rows instead of 45. Running the *same sparse kernel at ~full density* reproduced dense exactly (50.0 vs 49.6, the same 45 collapsed rows, a perfect set overlap), so the kernel was never implicated.

## Re-evaluation

Llama-3.1-8B-Instruct, n=100 per subset, `SinkMasker(128) + LocalMasker(128) + OracleTopK(heavy)` with `heavy` set so sink + local + heavy sums to the stated density. One subset per process (`benchmark/base.py:166` truncates the *concatenated* frame). All 81 cells on H200, from a sha-pinned frozen tree; both BOS modes run from that same tree, `legacy` via a `tokenizer.encode` monkeypatch that restores `add_special_tokens=True`. Every cell probes its own BOS count and aborts if it does not observe 1 (fixed) or 3 (legacy). 16.8 GPU-hours, zero failures.

`max_context_length` was chosen from a measured preflight so no cell clips the haystack (longest templated context 32,733 / 65,474 / 131,048 against budgets of 33,500 / 66,000 / 131,072). Per-row generation budgets are RULER's own and identical at all three lengths (fwe 50, vt 30, qa 32, niah 128), and the three `calculate_metrics.py` copies are md5-identical, so metric routing does not vary by length.

### Macro scores

| ctx | arm | pre-fix | **post-fix** |
|---|---|---|---|
| 32k | dense | 88.22 | **88.75** |
| | oracle5 | 83.87 | **87.41** |
| | oracle2 | 74.00 | **78.91** |
| 64k | dense | 83.97 | **86.52** |
| | oracle5 | 79.62 | **84.78** |
| | oracle2 | 65.43 | **72.50** |
| 128k | dense | 60.38 | **71.31** |
| | oracle5 | 56.98 | **63.27** |
| | oracle2 | 50.72 | **56.29** |

### Post-fix, per subset

| ctx | arm | fwe | vt | qa_1 | qa_2 | nm2 | nm3 | Macro |
|---|---|---|---|---|---|---|---|---|
| 32k | dense | 93.33 | 99.20 | 88.00 | 52.00 | 100.00 | 100.00 | **88.75** |
| | oracle5 | 90.67 | 98.80 | 84.00 | 52.00 | 100.00 | 99.00 | 87.41 |
| | oracle2 | 81.67 | 97.80 | 80.00 | 51.00 | 87.00 | 76.00 | 78.91 |
| 64k | dense | 86.33 | 98.80 | 84.00 | 53.00 | 98.00 | 99.00 | **86.52** |
| | oracle5 | 85.67 | 98.00 | 82.00 | 53.00 | 95.00 | 95.00 | 84.78 |
| | oracle2 | 79.00 | 96.00 | 77.00 | 49.00 | 78.00 | 56.00 | 72.50 |
| 128k | dense | 73.67 | 66.20 | 83.00 | 47.00 | 91.00 | 67.00 | **71.31** |
| | oracle5 | 68.00 | 64.60 | 70.00 | 41.00 | 85.00 | 51.00 | 63.27 |
| | oracle2 | 61.33 | 65.40 | 67.00 | 41.00 | 71.00 | 32.00 | 56.29 |

### The vt@128k inversion is gone

| vt @128k | dense | oracle2 | oracle5 | spread |
|---|---|---|---|---|
| pre-fix | 49.60 | **70.00** | 53.20 | 20.4, nonsensical order |
| **post-fix** | **66.20** | 65.40 | 64.60 | **1.6, dense on top** |

**Across all 36 paired dense-vs-sparse comparisons post-fix (3 lengths × 6 subsets × 2 densities), there is not one cell where a sparse arm is ahead of dense.** Pre-fix there were two: vt@128k (+20.40, exact paired sign test **p = 0.0002**) and qa_1@64k (+2.00, n.s.).

Monotonicity `dense ≥ oracle5 ≥ oracle2` holds in **17 of 18** post-fix cells. The exception is vt@128k, where oracle2 (65.40) sits 0.80 above oracle5 (64.60) — 16 rows up, 18 down, **p = 0.8642**, i.e. noise, with dense above both.

### Precision control

`dense` runs the model's native bf16 SDPA while every sparse arm goes through `mask_attention_utils.py`, which upcasts q/k/v to float32 — so a raw dense-vs-sparse delta confounds density with precision, in the direction that *flatters* the sparse arms. A `full` arm (`OracleTopK(heavy_size=1.0)`, which short-circuits to a full mask) selects every key through that same float32 path:

| `full` − `dense` | 32k | 64k | 128k |
|---|---|---|---|
| vt | 0.00 | −0.40 | +0.60 (p = 0.63) |
| nm3 | 0.00 | 0.00 | +1.00 (p = 1.00) |

The kernel is worth at most 1 point, and the ordering survives the stricter precision-matched form: at 128k `vt`, `full` 66.80 > oracle2 65.40 > oracle5 64.60; at `nm3`, `full` 68.00 > oracle5 51.00 > oracle2 32.00.

Measured density landed on target in all 50 sparse cells: oracle2 ∈ [0.0200, 0.0204], oracle5 ∈ [0.0500, 0.0504].

## Where the fix *hurts*

Not every delta is positive, and one is worth a reviewer's attention:

**`fwe` @128k regresses, 75.67 → 73.67.** Per-row: 7 rows down, 1 up, Wilcoxon p = 0.048, bootstrap CI [−4.67, −0.33] excluding zero. It does **not** survive Holm correction across the 12 pre/post pairs (adjusted p ≈ 0.42), so it is suggestive rather than established. There is no length component — both arms name exactly 3.00 words on every row — and the loss is concentrated on the rarest of the three gold words. `fwe` @64k (−0.33) and `niah_multikey_3` @64k (−1.00, one row off a ceiling of 100) are noise.

Repeat runs of identical cells differ by up to 0.34 points at 128k (bf16 non-associativity), which sets the floor for reading any single delta.

## How to read the numbers

- **Five of six subsets have a true zero floor.** `qa_2` does not: seven of its 100 golds are literally `no`, which `string_match_part` matches inside `know` / `not` / `cannot`, and an eighth point comes from gold `Ann` inside `answer`. A refusal scores **7–8** and an adversarial `"yes and no"` reaches **12.00**, identically at all three lengths. Subtract that floor before reading a `qa_2` delta. In practice the model answers 8 of the 12 yes/no rows correctly with zero substring accidents, so the floor bounds the metric without inflating these scores.
- **Cross-length comparison is between matched *tasks*, not matched *rows*.** The 32k dataset is a separate RULER generation (200 rows/subset) from the 64k/128k ones (500). Anchors, schema and per-row budgets are identical, but the needles differ. The within-length dense-vs-sparse comparison *is* row-paired, and that is where the statistics are.
- **Sparsity applies to the question and decode steps, not the context prefill** — `process_request` builds the KV cache outside `enable_sparse_mode()`. The reported density is the fraction of the KV each decode-time query attends to, not a KV-cache compression ratio.
- **At 128k a handful of rows run past `max_position_embeddings`** during generation, at most 77 tokens, on `fwe` and `niah_multikey_2` only. RoPE extrapolates; no cell crashed.

## Tests

`tests/unit/adapters/test_huggingface_special_tokens.py` — two fully-mocked tests, no network, no CUDA. A `FakeTokenizer` reproduces both real BOS sources independently (the literal marker the template writes into the string, and a `TemplateProcessing`-style prepend) and records the `add_special_tokens` kwarg each `encode()` received.

Mutation-checked against the pre-fix source: both **fail**, with exactly the observed signature —

```
AssertionError: expected exactly one BOS in the assembled sequence, got 3 at positions [0, 1, 7]
AssertionError: expected exactly one BOS in the assembled sequence, got 2 at positions [0, 5]
```

Full unit suite, clean tree vs fixed tree: `4 failed, 867 passed, 8 skipped, 81 errors` on **both**, with identical failing sets — all environmental (missing `/tmp/DoubleSparse` configs, one statistical tolerance). `black`, `isort`, `flake8` clean on both changed files.

Worth noting why this was never caught: no unit test called `process_request` at all, and the integration tests that do assert only `isinstance(response, str)` — with a fixture model of `Qwen/Qwen3-1.7B`, which has `bos_token=None`. The suite was structurally blind to the bug.

## Behaviour changes a reviewer should know about

1. **Base (no-chat-template) models change too** — their question tokens no longer carry a mid-sequence BOS.
2. **A narrow new failure mode.** With no chat template, an empty `answer_prefix` *and* an empty question, the question now encodes to a length-0 tensor where it was previously `[BOS]`. Crashing is arguably correct — `_generate_response` already raises `ValueError("Question tokens are empty…")` on the hybrid path — but it is a behaviour change. No benchmark here produces that input.
3. **Truncation shifts by one.** `context_tokens[:, :max_context_length]` now retains one more real content token on chat-template models, so results are not bit-identical to pre-fix runs at a pinned `max_context_length`.

## Still-open issues, unchanged from the first review

All pre-existing on `main`, affecting `ruler16k`/`ruler32k` equally, and out of scope here:

1. **`base.py:166` truncates the concatenated frame**, so `max_requests=100` over six subsets scores 100 rows of the *first* subset only.
2. **`base.py:191-193` mutates the caller's `generation_kwargs`**, ratcheting `max_new_tokens` down across subsets within one call.
3. **`process_request` prefills without `logits_to_keep`**, materialising logits for every position — 33.6 GB of bf16 logits at 128k, roughly half the measured 71 GiB peak, and the reason a 128k cell needs an H200 rather than an 80 GiB card.
4. **Neither benchmark pins a dataset revision.** This repo does not own the upstream 64k/128k repos, so pinning is worth a follow-up.

Item 5 from the first review — that dense and sparse are not numerically comparable — is now **resolved** by the `full` control above: the effect is at most 1 point.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LECTf5cNnGER9CvmECZvBs
