### PR TITLE
vAttention++: spend the sampling budget by importance sampling

### DIFF
--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/base.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/base.py
@@ -125,6 +125,35 @@ class ResearchMasker(ABC):
         )
         return Mask.create_full_mask(mask_shape, dtype=dtype, device=device)
 
+    @staticmethod
+    def publish_heavy_scores(
+        sparse_meta_data: Dict[Any, Any],
+        layer_idx: int,
+        scores: torch.Tensor,
+        init_offset: int,
+    ) -> None:
+        """Offer this masker's per-key scores to a later sampling masker.
+
+        Entirely optional. ``AdaptiveSamplingMasker`` in an importance-sampling
+        mode will reuse these as its proposal logits when they cover its window,
+        instead of falling back to the exact ``log(expwts)`` it computes anyway;
+        a heavy masker that does not publish simply gets the exact fallback.
+
+        Args:
+            sparse_meta_data: the per-request metadata dict.
+            layer_idx: the layer these scores belong to.
+            scores: ``[batch, num_query_heads, seq_len_queries, n_scored]``
+                RAW scores, on whatever axis the masker natively produces --
+                the consumer rescales onto the attention-logit axis.
+            init_offset: key index that column 0 of ``scores`` corresponds to.
+
+        Only the current layer is retained: these tensors are large (~8 GB
+        across 32 layers at the question step for an 8B model at 32k) and no
+        consumer ever reads another layer's entry.
+        """
+        sparse_meta_data["heavy_scores"] = {layer_idx: scores}
+        sparse_meta_data["heavy_score_offset"] = {layer_idx: init_offset}
+
     def _create_mask_from_rowise_indices(
         self,
         dims: AttentionTensorDimensions,

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/pq_top_k.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/pq_top_k.py
@@ -141,13 +141,12 @@ class PQCache(TopKMasker):
             queries, keys, centroids, codebook
         )
 
-        # Published so a later masker (AdaptiveSampling in an importance-sampling
-        # mode) can reuse these as proposal logits instead of recomputing q.k.
-        # Only the CURRENT layer is retained: these are [b, h, q, n_clustered],
-        # ~8 GB across 32 layers at the question step for an 8B model at 32k,
-        # and no consumer ever reads another layer's entry.
-        sparse_meta_data["pq_scores"] = {layer_idx: scores}
-        sparse_meta_data["pq_score_offset"] = {layer_idx: self.init_offset}
+        # Optional: offer these to a later sampling masker as proposal logits.
+        # Nothing requires it -- a heavy masker that does not publish just gets
+        # AdaptiveSampling's exact log(expwts) fallback instead.
+        self.publish_heavy_scores(
+            sparse_meta_data, layer_idx, scores, self.init_offset
+        )
 
         # Phase 5: Create mask from scores
         pq_mask: Mask = self._create_pq_mask(

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/pq_top_k.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/pq_top_k.py
@@ -141,6 +141,14 @@ class PQCache(TopKMasker):
             queries, keys, centroids, codebook
         )
 
+        # Published so a later masker (AdaptiveSampling in an importance-sampling
+        # mode) can reuse these as proposal logits instead of recomputing q.k.
+        # Only the CURRENT layer is retained: these are [b, h, q, n_clustered],
+        # ~8 GB across 32 layers at the question step for an 8B model at 32k,
+        # and no consumer ever reads another layer's entry.
+        sparse_meta_data["pq_scores"] = {layer_idx: scores}
+        sparse_meta_data["pq_score_offset"] = {layer_idx: self.init_offset}
+
         # Phase 5: Create mask from scores
         pq_mask: Mask = self._create_pq_mask(
             tensor_dims, scores, effective_heavy_size, previous_mask, keys.device

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/pq_top_k.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/pq_top_k.py
@@ -144,9 +144,7 @@ class PQCache(TopKMasker):
         # Optional: offer these to a later sampling masker as proposal logits.
         # Nothing requires it -- a heavy masker that does not publish just gets
         # AdaptiveSampling's exact log(expwts) fallback instead.
-        self.publish_heavy_scores(
-            sparse_meta_data, layer_idx, scores, self.init_offset
-        )
+        self.publish_heavy_scores(sparse_meta_data, layer_idx, scores, self.init_offset)
 
         # Phase 5: Create mask from scores
         pq_mask: Mask = self._create_pq_mask(

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
@@ -366,27 +366,32 @@ class AdaptiveSamplingMasker(SamplingMasker):
     ) -> torch.Tensor:
         """Proposal logits over ``[start_idx, end_idx)``, already-taken keys -inf.
 
-        Reuses the scores a preceding heavy masker published in
-        ``sparse_meta_data["pq_scores"]`` when they cover this window, so the
-        sampling stage does not recompute ``q . k``; otherwise falls back to
-        ``log(expwts)``, the attention scores this masker already computed for
-        the vAttention budget.
+        The heavy masker in front of this one is irrelevant to the mechanism.
+        Two proposal sources, tried in order:
 
-        Both sources come back on the TRUE ATTENTION-LOGIT axis, so
-        ``temperature`` means the same thing whichever one fires. PQCache
-        publishes raw ``q . k_hat``, while the attention logit is
-        ``scaling * q . k`` -- and ``scaling = 1/sqrt(head_dim) = 0.088`` for a
-        128-dim head. Sampling the unscaled score at ``temperature=1`` is
-        sampling the real logit at ``temperature=0.088``, which collapses the
-        draw onto the deterministic top-k.
+        1. Whatever a preceding masker offered through
+           ``ResearchMasker.publish_heavy_scores`` (PQCache does; nothing is
+           required to), when it covers this window.
+        2. Otherwise ``log(expwts)`` -- the exact attention logits this masker
+           already computed for the vAttention budget, so the fallback costs
+           nothing extra and works behind ANY heavy masker (OracleTopK, Quest,
+           HashAttention, DoubleSparsity, Socket, or no heavy masker at all).
+
+        Both come back on the TRUE ATTENTION-LOGIT axis, so ``temperature``
+        means the same thing whichever fires. PQCache publishes raw
+        ``q . k_hat``, while the attention logit is ``scaling * q . k`` -- and
+        ``scaling = 1/sqrt(head_dim) = 0.088`` for a 128-dim head. Sampling the
+        unscaled score at ``temperature=1`` is sampling the real logit at
+        ``temperature=0.088``, which collapses the draw onto the deterministic
+        top-k.
         """
         window: torch.Tensor = expwts[..., start_idx:end_idx]
         sampling_range: int = end_idx - start_idx
         scores: Optional[torch.Tensor] = None
         layer_idx = kwargs.get("layer_idx")
         if layer_idx is not None:
-            published = sparse_meta_data.get("pq_scores", {}).get(layer_idx)
-            offset = sparse_meta_data.get("pq_score_offset", {}).get(layer_idx)
+            published = sparse_meta_data.get("heavy_scores", {}).get(layer_idx)
+            offset = sparse_meta_data.get("heavy_score_offset", {}).get(layer_idx)
             if published is not None and offset is not None:
                 rel_start: int = start_idx - int(offset)
                 rel_end: int = end_idx - int(offset)

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
@@ -11,7 +11,7 @@ The AdaptiveSamplingMasker is useful for:
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 from ray import tune
@@ -20,6 +20,11 @@ from scipy.stats import norm
 from sparse_attention_hub.sparse_attention.research_attention.maskers.base import (
     MaskerConfig,
     MaskerRegistry,
+)
+from sparse_attention_hub.sparse_attention.research_attention.maskers.sampling.implementations.utils.importance_sampling_utils import (
+    SAMPLING_MODES,
+    gumbel_topk_with_inclusion,
+    multinomial_with_inclusion,
 )
 from sparse_attention_hub.sparse_attention.utils.mask import Mask
 from sparse_attention_hub.sparse_attention.utils.mask_attention_utils import (
@@ -51,6 +56,26 @@ class AdaptiveSamplingMaskerConfig(SamplingMaskerConfig):
         local_offset: Union[int, float] representing the end offset for sampling.
             If int, must be non-negative; if float, must be in [0,1] and will be
             multiplied by the number of keys to get the actual offset.
+        sampling_mode: How the adaptive budget is SPENT. The budget SIZE is the
+            original vAttention (epsilon, delta, base_rate_sampling) rule in
+            every mode; only the draw changes.
+
+            * ``"uniform"`` (default): the published vAttention draw -- uniform
+              with replacement over ``[init_offset, seq_len - local_offset)``.
+            * ``"multinomial"``: exact importance sampling. ``budget`` i.i.d.
+              draws from ``softmax(logits / temperature)`` over the leftover
+              keys, weighted by the exact inclusion probability
+              ``1 - (1 - p_i) ** budget``.
+            * ``"gumbel"``: the Gumbel-top-k approximation of the same draw --
+              one ``topk`` over ``logits + temperature * Gumbel(0, 1)``,
+              weighted by ``1 - exp(-exp((l_i - kappa) / temperature))``.
+
+            The default stays ``"uniform"`` so every existing vAttention config
+            keeps the behaviour it was tuned and published with.
+        temperature: Sampling temperature, in TRUE ATTENTION-LOGIT units. The
+            proposal is rescaled onto that axis before the draw, so
+            ``temperature=1.0`` samples each key with probability rising in
+            proportion to its attention weight.
     """
 
     base_rate_sampling: Union[int, float]  # Base rate (0,1) if float
@@ -58,6 +83,8 @@ class AdaptiveSamplingMaskerConfig(SamplingMaskerConfig):
     delta: float  # Confidence bound (0,1)
     init_offset: Union[int, float]  # Start index
     local_offset: Union[int, float]  # End offset
+    sampling_mode: str = "uniform"
+    temperature: float = 1.0
     search_space: Dict[str, Any] = field(
         default_factory=lambda: {
             "base_rate_sampling": tune.grid_search([0.01, 0.02, 0.03]),
@@ -119,6 +146,20 @@ class AdaptiveSamplingMaskerConfig(SamplingMaskerConfig):
                 f"local_offset must be int or float, got {type(self.local_offset)}"
             )
 
+        if self.sampling_mode not in SAMPLING_MODES:
+            raise ValueError(
+                f"sampling_mode must be one of {SAMPLING_MODES}, "
+                f"got {self.sampling_mode!r}"
+            )
+        if self.temperature < 0:
+            raise ValueError(f"temperature must be >= 0, got {self.temperature}")
+        if self.sampling_mode != "uniform" and self.temperature == 0:
+            raise ValueError(
+                "temperature=0 turns importance sampling into a second "
+                "deterministic top-k with no Horvitz-Thompson correction; "
+                "use sampling_mode='uniform' if that is what you want"
+            )
+
 
 @MaskerRegistry.register(AdaptiveSamplingMaskerConfig)
 class AdaptiveSamplingMasker(SamplingMasker):
@@ -144,7 +185,17 @@ class AdaptiveSamplingMasker(SamplingMasker):
     Important Notes:
         - If base_rate_sampling is set to 0, the masker returns the previous mask
           without any modification.
-        - The sampling is performed with replacement for efficiency.
+        - Budget SIZE is the original vAttention (epsilon, delta, base_rate)
+          rule in every mode; sampling_mode only changes how it is spent.
+        - sampling_mode="uniform" (default) is the published draw: uniform with
+          replacement over the whole window. It is performed with replacement
+          for efficiency.
+        - sampling_mode="multinomial" / "gumbel" spend the same budget on the
+          LEFTOVER keys only (positions not already taken by sink, local or a
+          heavy top-k masker), drawn with probability rising in the attention
+          logit. Mask values are inclusion probabilities; attention inverts them
+          via apply_inv_mask, which is what makes the estimator
+          Horvitz-Thompson.
         - The masker ignores the previous mask for base sampling to avoid complex
           index manipulation.
         - Merge operation adds the data in masks and clamps to 1.0.
@@ -176,6 +227,8 @@ class AdaptiveSamplingMasker(SamplingMasker):
         self.delta = config.delta
         self.init_offset = config.init_offset
         self.local_offset = config.local_offset
+        self.sampling_mode = config.sampling_mode
+        self.temperature = config.temperature
 
         # Pre-compute delta_ppf for efficiency
         self.delta_ppf = float(norm.ppf(1 - self.delta))
@@ -301,6 +354,100 @@ class AdaptiveSamplingMasker(SamplingMasker):
 
         return budget
 
+    def _get_leftover_scores(
+        self,
+        expwts: torch.Tensor,
+        previous_mask: Mask,
+        start_idx: int,
+        end_idx: int,
+        sparse_meta_data: Dict[Any, Any],
+        kwargs: Dict[str, Any],
+        scaling: float,
+    ) -> torch.Tensor:
+        """Proposal logits over ``[start_idx, end_idx)``, already-taken keys -inf.
+
+        Reuses the scores a preceding heavy masker published in
+        ``sparse_meta_data["pq_scores"]`` when they cover this window, so the
+        sampling stage does not recompute ``q . k``; otherwise falls back to
+        ``log(expwts)``, the attention scores this masker already computed for
+        the vAttention budget.
+
+        Both sources come back on the TRUE ATTENTION-LOGIT axis, so
+        ``temperature`` means the same thing whichever one fires. PQCache
+        publishes raw ``q . k_hat``, while the attention logit is
+        ``scaling * q . k`` -- and ``scaling = 1/sqrt(head_dim) = 0.088`` for a
+        128-dim head. Sampling the unscaled score at ``temperature=1`` is
+        sampling the real logit at ``temperature=0.088``, which collapses the
+        draw onto the deterministic top-k.
+        """
+        window: torch.Tensor = expwts[..., start_idx:end_idx]
+        sampling_range: int = end_idx - start_idx
+        scores: Optional[torch.Tensor] = None
+        layer_idx = kwargs.get("layer_idx")
+        if layer_idx is not None:
+            published = sparse_meta_data.get("pq_scores", {}).get(layer_idx)
+            offset = sparse_meta_data.get("pq_score_offset", {}).get(layer_idx)
+            if published is not None and offset is not None:
+                rel_start: int = start_idx - int(offset)
+                rel_end: int = end_idx - int(offset)
+                # The leading dims are checked too: the cache is keyed only by
+                # layer, so a prefill entry would otherwise be reused at decode.
+                if (
+                    published.shape[:-1] == window.shape[:-1]
+                    and rel_start >= 0
+                    and rel_end <= published.shape[-1]
+                    and rel_end - rel_start == sampling_range
+                ):
+                    scores = published[..., rel_start:rel_end].to(torch.float32)
+                    scores = scores * scaling
+
+        if scores is None:
+            scores = torch.log(window.to(torch.float32).clamp_min(1e-20))
+
+        leftover: torch.Tensor = scores.clone().to(torch.float32)
+        previous_slice: torch.Tensor = previous_mask.get_dense_mask()[
+            ..., start_idx:end_idx
+        ].to(device=leftover.device)
+        leftover[previous_slice != 0] = float("-inf")
+        # Keys the attention mask kills (future / padding) contribute exactly
+        # zero to the output, so budget spent on them is wasted. In the expwts
+        # fallback they arrive as an underflowed 0.0 that log() floors at a
+        # FINITE -46, which any isfinite() liveness test would count as live.
+        leftover[window == 0] = float("-inf")
+        return leftover
+
+    def _create_importance_sampling_mask(
+        self,
+        leftover_scores: torch.Tensor,
+        budget: torch.Tensor,
+        seq_len_keys: int,
+        start_idx: int,
+        dtype: torch.dtype,
+    ) -> Mask:
+        """Draw the budget from the leftovers; mask values are inclusion probs.
+
+        The mask stores ``pi_i``, not ``1 / pi_i``: ``Mask.apply_inv_mask``
+        divides by the stored value, and that division is what produces the
+        Horvitz-Thompson weight. Storing the reciprocal would both invert the
+        correction and be erased by ``merge_mask``'s ``clamp(m1 + m2, 0, 1)``.
+        """
+        draw = (
+            multinomial_with_inclusion
+            if self.sampling_mode == "multinomial"
+            else gumbel_topk_with_inclusion
+        )
+        _indices, _inclusion, _valid, dense_pi = draw(
+            leftover_scores, budget, self.temperature
+        )
+        dense: torch.Tensor = torch.zeros(
+            *leftover_scores.shape[:-1],
+            seq_len_keys,
+            device=leftover_scores.device,
+            dtype=dtype,
+        )
+        dense[..., start_idx : start_idx + dense_pi.shape[-1]] = dense_pi.to(dtype)
+        return Mask.create_mask_from_dense_mask(dense.shape, dense, dtype=dtype)
+
     def add_mask(
         self,
         keys: torch.Tensor,
@@ -393,16 +540,34 @@ class AdaptiveSamplingMasker(SamplingMasker):
         )
         budget = torch.clamp(budget, min=num_base_samples, max=sampling_range)
 
-        # Create adaptive sampling mask
-        sampling_probabilities = (budget / sampling_range).to(previous_mask.dtype)
-        adaptive_mask = create_sampling_mask_with_per_head_budget(
-            budgets=budget,
-            sampling_probability=sampling_probabilities,
-            seq_len_keys=seq_len_keys,
-            start_idx=start_idx,
-            end_idx=end_idx,
-            dtype=previous_mask.dtype,
-        )
+        # Spend the budget. The budget itself is identical in every mode.
+        if self.sampling_mode == "uniform":
+            sampling_probabilities = (budget / sampling_range).to(previous_mask.dtype)
+            adaptive_mask = create_sampling_mask_with_per_head_budget(
+                budgets=budget,
+                sampling_probability=sampling_probabilities,
+                seq_len_keys=seq_len_keys,
+                start_idx=start_idx,
+                end_idx=end_idx,
+                dtype=previous_mask.dtype,
+            )
+        else:
+            leftover_scores = self._get_leftover_scores(
+                expwts,
+                previous_mask,
+                start_idx,
+                end_idx,
+                sparse_meta_data,
+                kwargs,
+                scaling,
+            )
+            adaptive_mask = self._create_importance_sampling_mask(
+                leftover_scores,
+                budget,
+                seq_len_keys,
+                start_idx,
+                previous_mask.dtype,
+            )
         # Merge masks
         return previous_mask.merge_mask(adaptive_mask, inplace=False)
 

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/adaptive_sampling.py
@@ -208,6 +208,27 @@ class AdaptiveSamplingMasker(SamplingMasker):
         ... )
         >>> masker = AdaptiveSamplingMasker(config)
         >>> # Use masker.add_mask() to apply adaptive sampling to attention masks
+
+        vAttention++ is the same chain with one field changed. The heavy masker
+        is whatever you want it to be -- swap PQCacheConfig for OracleTopKConfig,
+        QuestTopKMaskerConfig, HashAttentionTopKMaskerConfig, ... and nothing
+        else moves:
+
+        >>> ResearchAttentionConfig(masker_configs=[
+        ...     SinkMaskerConfig(sink_size=128),
+        ...     LocalMaskerConfig(window_size=127),
+        ...     PQCacheConfig(heavy_size=0.008, pq_group_factor=16, pq_bits=8,
+        ...                   kmeans_iter=10, init_offset=128, metric="euclidean"),
+        ...     AdaptiveSamplingMaskerConfig(
+        ...         base_rate_sampling=0.002, epsilon=0.1, delta=0.1,
+        ...         init_offset=128, local_offset=127,
+        ...         sampling_mode="multinomial",  # or "gumbel"; "uniform" is vAttention
+        ...         temperature=1.0,
+        ...     ),
+        ... ])
+
+        `init_offset` / `local_offset` should match the sink and local sizes, so
+        the sampler's window is exactly the region neither of them covers.
     """
 
     def __init__(self, config: AdaptiveSamplingMaskerConfig) -> None:

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/utils/__init__.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/utils/__init__.py
@@ -1,0 +1,15 @@
+"""Utilities for sampling maskers."""
+
+from .importance_sampling_utils import (
+    SAMPLING_MODES,
+    gumbel_topk_with_inclusion,
+    multinomial_with_inclusion,
+    sample_gumbel_noise,
+)
+
+__all__ = [
+    "SAMPLING_MODES",
+    "gumbel_topk_with_inclusion",
+    "multinomial_with_inclusion",
+    "sample_gumbel_noise",
+]

--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/utils/importance_sampling_utils.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/sampling/implementations/utils/importance_sampling_utils.py
@@ -1,0 +1,261 @@
+"""Importance-sampling draws with per-row inclusion probabilities.
+
+Two ways to spend a sampling budget on a set of proposal logits, both returning
+``P(i in S)`` so the caller can build a Horvitz-Thompson estimator:
+
+* :func:`multinomial_with_inclusion` -- exact. ``m`` independent draws with
+  replacement from ``p = softmax(s / T)`` (``torch.multinomial``); the unique
+  set ``S`` then has the exact closed-form inclusion probability
+  ``pi_i = 1 - (1 - p_i) ** m``. Duplicates are not a problem -- they collapse
+  into one mask position, which that formula already accounts for.
+* :func:`gumbel_topk_with_inclusion` -- the Gumbel-top-k (priority sampling)
+  approximation. One ``topk`` over ``s + T * Gumbel(0, 1)``, with
+  ``pi_i = 1 - exp(-exp((s_i - kappa) / T))`` for the ``(k+1)``-th perturbed
+  order statistic ``kappa``. One kernel cheaper, and the ``k`` keys are
+  distinct so the whole budget buys distinct keys; the price is that ``pi_i``
+  is exact only conditional on the observed ``kappa``.
+
+Both expect proposal logits on the SAME AXIS as the attention logits, i.e.
+``scaling * q . k``. A masker reusing a heavy masker's raw scores (PQCache
+publishes raw ``q . k_hat``) must rescale first, or ``temperature`` reads about
+``sqrt(head_dim)`` times colder than it looks and the draw degenerates into the
+deterministic top-k.
+
+Mask values in this hub are inclusion probabilities, never their reciprocal:
+:meth:`Mask.apply_inv_mask` divides by the stored value, and that division is
+what produces the Horvitz-Thompson weight ``1 / pi_i``.
+"""
+
+from typing import Tuple, Union
+
+import torch
+
+SAMPLING_MODES: Tuple[str, ...] = ("uniform", "gumbel", "multinomial")
+
+# keeps -log(-log(u)) finite at both ends of the uniform sample
+_UNIFORM_EPS: float = 1e-6
+# floor on pi_i so 1 / pi_i cannot blow up on a near-zero probability
+_MIN_INCLUSION_PROBABILITY: float = 1e-4
+
+
+def _as_budget_tensor(
+    k: Union[int, torch.Tensor], scores: torch.Tensor
+) -> torch.Tensor:
+    """Normalise a scalar or ``[..., 1]`` budget to a ``[..., 1]`` int64 tensor."""
+    if isinstance(k, int):
+        return torch.full(
+            (*scores.shape[:-1], 1), k, device=scores.device, dtype=torch.long
+        )
+    k_tensor: torch.Tensor = k.to(device=scores.device, dtype=torch.long)
+    if k_tensor.shape[-1] != 1:
+        k_tensor = k_tensor.unsqueeze(-1)
+    return k_tensor
+
+
+def _empty_result(
+    scores: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """The no-budget result: nothing drawn, nothing included."""
+    return (
+        torch.zeros(*scores.shape[:-1], 1, device=scores.device, dtype=torch.long),
+        torch.zeros(*scores.shape[:-1], 1, device=scores.device, dtype=scores.dtype),
+        torch.zeros(*scores.shape[:-1], 1, device=scores.device, dtype=torch.bool),
+        torch.zeros_like(scores),
+    )
+
+
+def sample_gumbel_noise(reference: torch.Tensor) -> torch.Tensor:
+    """Draw standard Gumbel(0, 1) noise shaped like ``reference``, in float32."""
+    uniform: torch.Tensor = torch.rand(
+        reference.shape, device=reference.device, dtype=torch.float32
+    ).clamp_(min=_UNIFORM_EPS, max=1.0 - _UNIFORM_EPS)
+    return -torch.log(-torch.log(uniform))
+
+
+def multinomial_with_inclusion(
+    scores: torch.Tensor,
+    k: Union[int, torch.Tensor],
+    temperature: float,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Exact importance sampling: ``m`` i.i.d. draws from ``softmax(s / T)``.
+
+    Args:
+        scores: ``[..., n]`` proposal logits. ``-inf`` marks positions that must
+            not be sampled (already taken by sink / local / the heavy top-k, or
+            killed by the attention mask); they get ``p_i = 0``.
+        k: scalar or ``[..., 1]`` per-row number of draws ``m``.
+        temperature: softmax temperature. ``0`` degenerates to a deterministic
+            top-k with ``pi_i = 1``, i.e. plain truncation with no reweighting.
+
+    Returns:
+        indices: ``[..., k_max]`` drawn positions (may repeat).
+        inclusion: ``[..., k_max]`` ``pi`` of each draw.
+        valid: ``[..., k_max]`` True for real draws (False is padding).
+        dense_inclusion: ``[..., n]`` ``pi_i`` on the unique drawn set, else 0.
+    """
+    num_scored: int = scores.shape[-1]
+    logits: torch.Tensor = scores.to(torch.float32)
+    live: torch.Tensor = torch.isfinite(logits)
+    n_live: torch.Tensor = live.sum(dim=-1, keepdim=True)
+    budget: torch.Tensor = _as_budget_tensor(k, scores).clamp(min=0)
+    # With replacement there is no reason to cap m at n_live, but a row with
+    # nothing live has no distribution to draw from.
+    effective_m: torch.Tensor = torch.where(
+        n_live > 0, budget, torch.zeros_like(budget)
+    )
+    k_max: int = int(effective_m.max().item()) if effective_m.numel() else 0
+    if k_max <= 0:
+        return _empty_result(scores)
+
+    col: torch.Tensor = torch.arange(k_max, device=scores.device).view(
+        *([1] * (scores.ndim - 1)), k_max
+    )
+
+    if temperature == 0.0:
+        indices: torch.Tensor = torch.topk(
+            logits, k=min(k_max, num_scored), dim=-1, largest=True
+        ).indices
+        valid: torch.Tensor = (col < effective_m) & live.gather(dim=-1, index=indices)
+        inclusion: torch.Tensor = torch.where(
+            valid,
+            torch.ones_like(indices, dtype=scores.dtype),
+            torch.zeros_like(indices, dtype=scores.dtype),
+        )
+        return (
+            indices,
+            inclusion,
+            valid,
+            _scatter_unique(scores, indices, inclusion, valid),
+        )
+
+    masked_logits: torch.Tensor = torch.where(
+        live, logits / temperature, torch.full_like(logits, float("-inf"))
+    )
+    probabilities: torch.Tensor = torch.softmax(masked_logits, dim=-1)
+    probabilities = torch.where(
+        torch.isfinite(probabilities), probabilities, torch.zeros_like(probabilities)
+    )
+    row_mass: torch.Tensor = probabilities.sum(dim=-1, keepdim=True)
+    # A dead row would make torch.multinomial raise; give it a dummy
+    # distribution and drop its draws through `valid`.
+    uniform: torch.Tensor = torch.full_like(probabilities, 1.0 / max(num_scored, 1))
+    safe: torch.Tensor = torch.where(row_mass > 0, probabilities, uniform)
+    indices = torch.multinomial(
+        safe.reshape(-1, num_scored), k_max, replacement=True
+    ).reshape(*scores.shape[:-1], k_max)
+    valid = (col < effective_m) & (row_mass > 0)
+
+    # pi_i = 1 - (1 - p_i)^m, as -expm1(m * log1p(-p)) so a tiny p does not
+    # underflow to exactly 0 and blow the 1/pi weight up to infinity.
+    pi_all: torch.Tensor = -torch.expm1(
+        effective_m.to(torch.float32)
+        * torch.log1p((-probabilities.clamp(0.0, 1.0)).clamp(min=-1.0, max=0.0))
+    )
+    pi_all = pi_all.clamp(min=_MIN_INCLUSION_PROBABILITY, max=1.0)
+    inclusion = torch.gather(pi_all, dim=-1, index=indices).to(scores.dtype)
+    inclusion = torch.where(valid, inclusion, torch.zeros_like(inclusion))
+    return indices, inclusion, valid, _scatter_unique(scores, indices, inclusion, valid)
+
+
+def gumbel_topk_with_inclusion(
+    scores: torch.Tensor,
+    k: Union[int, torch.Tensor],
+    temperature: float,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Gumbel-top-k: sample ``k`` DISTINCT keys and return inclusion probs.
+
+    Same signature and return shape as :func:`multinomial_with_inclusion`.
+
+    Args:
+        scores: ``[..., n]`` proposal logits; ``-inf`` is never selected.
+        k: scalar or ``[..., 1]`` per-row sample count.
+        temperature: Gumbel noise scale. ``0`` is a deterministic top-k with
+            ``pi_i = 1``.
+    """
+    num_scored: int = scores.shape[-1]
+    logits: torch.Tensor = scores.to(torch.float32)
+    live: torch.Tensor = torch.isfinite(logits)
+    n_live: torch.Tensor = live.sum(dim=-1, keepdim=True)
+    # Without replacement a row can never take more keys than it has live.
+    effective_k: torch.Tensor = torch.minimum(
+        _as_budget_tensor(k, scores).clamp(min=0), n_live
+    )
+    k_max: int = int(effective_k.max().item()) if effective_k.numel() else 0
+    if k_max <= 0:
+        return _empty_result(scores)
+
+    col: torch.Tensor = torch.arange(k_max, device=scores.device).view(
+        *([1] * (scores.ndim - 1)), k_max
+    )
+
+    if temperature == 0.0:
+        indices: torch.Tensor = torch.topk(
+            logits, k=min(k_max, num_scored), dim=-1, largest=True
+        ).indices
+        valid: torch.Tensor = (col < effective_k) & live.gather(dim=-1, index=indices)
+        inclusion: torch.Tensor = torch.where(
+            valid,
+            torch.ones_like(indices, dtype=scores.dtype),
+            torch.zeros_like(indices, dtype=scores.dtype),
+        )
+        return (
+            indices,
+            inclusion,
+            valid,
+            _scatter_unique(scores, indices, inclusion, valid),
+        )
+
+    perturbed: torch.Tensor = logits + temperature * sample_gumbel_noise(logits)
+    topk_k: int = min(k_max + 1, num_scored)
+    top_values, top_indices = torch.topk(perturbed, k=topk_k, dim=-1, sorted=True)
+    indices = top_indices[..., :k_max]
+    # Per-row threshold: the (k_i + 1)-th perturbed order statistic. A row whose
+    # k_i saturates its live set has no (k_i + 1)-th draw, so `take_all` below
+    # forces pi = 1 and the clamp only keeps the gather in bounds. This must NOT
+    # be widened to a whole-tensor -inf fallback -- one saturating row would
+    # then set pi = 1 for every other row and silently delete the reweighting.
+    threshold: torch.Tensor = torch.gather(
+        top_values, dim=-1, index=effective_k.clamp(max=topk_k - 1)
+    )
+    sampled_logits: torch.Tensor = torch.gather(logits, dim=-1, index=indices)
+    exponent: torch.Tensor = (sampled_logits - threshold) / temperature
+    inclusion_f32: torch.Tensor = -torch.expm1(-torch.exp(exponent))
+    inclusion_f32 = torch.where(
+        torch.isfinite(exponent), inclusion_f32, torch.ones_like(inclusion_f32)
+    ).clamp(min=_MIN_INCLUSION_PROBABILITY, max=1.0)
+    inclusion_f32 = torch.where(
+        effective_k >= n_live, torch.ones_like(inclusion_f32), inclusion_f32
+    )
+    valid = (col < effective_k) & torch.isfinite(sampled_logits)
+    inclusion = torch.where(valid, inclusion_f32, torch.zeros_like(inclusion_f32)).to(
+        scores.dtype
+    )
+    return indices, inclusion, valid, _scatter_unique(scores, indices, inclusion, valid)
+
+
+def _scatter_unique(
+    scores: torch.Tensor,
+    indices: torch.Tensor,
+    inclusion: torch.Tensor,
+    valid: torch.Tensor,
+) -> torch.Tensor:
+    """Place ``pi_i`` on the unique drawn set, zero elsewhere.
+
+    Uses ``scatter_`` (overwrite), not ``scatter_add_``: the multinomial draw is
+    WITH replacement, and a repeated index must contribute its ``pi_i`` once,
+    not once per draw. Padded slots are routed to a scratch column so they
+    cannot collide with a genuinely selected position 0.
+    """
+    num_scored: int = scores.shape[-1]
+    scratch: torch.Tensor = torch.zeros(
+        *scores.shape[:-1], num_scored + 1, device=scores.device, dtype=scores.dtype
+    )
+    safe_index: torch.Tensor = torch.where(
+        valid, indices, torch.full_like(indices, num_scored)
+    )
+    scratch.scatter_(
+        dim=-1,
+        index=safe_index,
+        src=torch.where(valid, inclusion, torch.zeros_like(inclusion)),
+    )
+    return scratch[..., :num_scored]

--- a/tests/unit/sparse_attention/research_attention/maskers/sampling/test_adaptive_sampling.py
+++ b/tests/unit/sparse_attention/research_attention/maskers/sampling/test_adaptive_sampling.py
@@ -806,3 +806,149 @@ class TestSamplingModeConfig:
     def test_rejects_negative_temperature(self):
         with pytest.raises(ValueError, match="temperature must be >= 0"):
             self._config(temperature=-1.0)
+
+
+
+@pytest.mark.unit
+class TestImportanceSamplingIsHeavyMaskerAgnostic:
+    """The sampling stage must not care which heavy masker preceded it.
+
+    PQCache publishes its scores and they get reused as the proposal; every
+    other heavy masker publishes nothing and the exact log(expwts) fallback
+    takes over. Both must produce a valid mask, and neither may re-select a key
+    the heavy stage already took.
+    """
+
+    HEAD_DIM = 32
+    SHAPE = (1, 4, 1, 256)
+
+    def _tensors(self):
+        torch.manual_seed(17)
+        batch, heads, queries, keys_len = self.SHAPE
+        return (
+            torch.randn(batch, heads, keys_len, self.HEAD_DIM),
+            torch.randn(batch, heads, queries, self.HEAD_DIM),
+            torch.randn(batch, heads, keys_len, self.HEAD_DIM),
+        )
+
+    def _heavy_masker(self, name):
+        from sparse_attention_hub.sparse_attention.research_attention.maskers.fixed.implementations import (  # noqa: E501
+            OracleTopK,
+            OracleTopKConfig,
+            PQCache,
+            PQCacheConfig,
+        )
+
+        if name == "oracle":
+            return OracleTopK(OracleTopKConfig(heavy_size=16))
+        return PQCache(
+            PQCacheConfig(
+                heavy_size=16,
+                pq_group_factor=2,
+                pq_bits=4,
+                kmeans_iter=2,
+                init_offset=8,
+                metric="euclidean",
+            )
+        )
+
+    @pytest.mark.parametrize("heavy", ["oracle", "pqcache"])
+    @pytest.mark.parametrize("mode", ["gumbel", "multinomial"])
+    def test_runs_behind_any_heavy_masker(self, heavy, mode):
+        from sparse_attention_hub.sparse_attention.research_attention.maskers.fixed.implementations import (  # noqa: E501
+            LocalMasker,
+            LocalMaskerConfig,
+            SinkMasker,
+            SinkMaskerConfig,
+        )
+
+        keys, queries, values = self._tensors()
+        chain = [
+            SinkMasker(SinkMaskerConfig(sink_size=8)),
+            LocalMasker(LocalMaskerConfig(window_size=8)),
+            self._heavy_masker(heavy),
+            AdaptiveSamplingMasker(
+                AdaptiveSamplingMaskerConfig(
+                    base_rate_sampling=0.05,
+                    epsilon=0.2,
+                    delta=0.2,
+                    init_offset=8,
+                    local_offset=8,
+                    sampling_mode=mode,
+                    temperature=1.0,
+                )
+            ),
+        ]
+        meta: dict = {}
+        mask = Mask.create_empty_mask(
+            self.SHAPE, dtype=torch.float32, device=torch.device("cpu")
+        )
+        heavy_dense = None
+        for masker in chain:
+            mask = masker.add_mask(
+                keys=keys,
+                queries=queries,
+                values=values,
+                attention_mask=None,
+                scaling=self.HEAD_DIM**-0.5,
+                dropout=0.0,
+                sparse_meta_data=meta,
+                previous_mask=mask,
+                layer_idx=0,
+            )
+            if masker is chain[2]:
+                heavy_dense = mask.get_dense_mask().clone()
+
+        dense = mask.get_dense_mask()
+        assert dense.shape == self.SHAPE
+        assert bool(torch.isfinite(dense).all())
+        # the heavy stage's picks are untouched, and the sampler adds new keys
+        # at a fractional inclusion probability rather than re-picking them
+        assert bool((dense[heavy_dense > 0] == 1.0).all())
+        fresh = (heavy_dense == 0) & (dense > 0)
+        assert bool(fresh.any()), f"{heavy}/{mode} sampled nothing"
+        assert bool((dense[fresh] > 0).all()) and bool((dense[fresh] <= 1.0).all())
+
+        # PQCache offers its scores; OracleTopK offers none and takes the
+        # exact log(expwts) fallback. Both must work.
+        assert ("heavy_scores" in meta) == (heavy == "pqcache")
+
+    def test_works_with_no_heavy_masker_at_all(self):
+        """Sink + Local + AdaptiveSampling, nothing to reuse."""
+        from sparse_attention_hub.sparse_attention.research_attention.maskers.fixed.implementations import (  # noqa: E501
+            SinkMasker,
+            SinkMaskerConfig,
+        )
+
+        keys, queries, values = self._tensors()
+        mask = Mask.create_empty_mask(
+            self.SHAPE, dtype=torch.float32, device=torch.device("cpu")
+        )
+        meta: dict = {}
+        for masker in (
+            SinkMasker(SinkMaskerConfig(sink_size=8)),
+            AdaptiveSamplingMasker(
+                AdaptiveSamplingMaskerConfig(
+                    base_rate_sampling=0.05,
+                    epsilon=0.2,
+                    delta=0.2,
+                    init_offset=8,
+                    local_offset=8,
+                    sampling_mode="multinomial",
+                )
+            ),
+        ):
+            mask = masker.add_mask(
+                keys=keys,
+                queries=queries,
+                values=values,
+                attention_mask=None,
+                scaling=self.HEAD_DIM**-0.5,
+                dropout=0.0,
+                sparse_meta_data=meta,
+                previous_mask=mask,
+                layer_idx=0,
+            )
+        dense = mask.get_dense_mask()
+        assert "heavy_scores" not in meta
+        assert bool((dense > 0).any()) and bool((dense <= 1.0).all())

--- a/tests/unit/sparse_attention/research_attention/maskers/sampling/test_adaptive_sampling.py
+++ b/tests/unit/sparse_attention/research_attention/maskers/sampling/test_adaptive_sampling.py
@@ -549,3 +549,260 @@ class TestAdaptiveSamplingMasker:
         dense_mask = result.get_dense_mask()
         assert torch.all(torch.isfinite(dense_mask))
         assert not torch.any(torch.isnan(dense_mask))
+
+
+@pytest.mark.unit
+class TestImportanceSamplingEstimator:
+    """The property the sampling modes exist for: an unbiased leftover estimate.
+
+    Every assertion here is on the ESTIMATOR, not on shapes. Each one fails if
+    the mask stores 1/pi instead of pi, if the proposal is left on the raw
+    (unscaled) PQ axis, or if a repeated multinomial draw is counted twice.
+    """
+
+    SHAPE = (1, 2, 1, 512)
+    START, END = 0, 512
+
+    def _leftover_logits(self, spread: float, seed: int) -> torch.Tensor:
+        generator = torch.Generator().manual_seed(seed)
+        return (
+            torch.randn(self.SHAPE, generator=generator, dtype=torch.float32) * spread
+        )
+
+    def _masker(self, mode: str, temperature: float = 1.0):
+        return AdaptiveSamplingMasker(
+            AdaptiveSamplingMaskerConfig(
+                base_rate_sampling=0.1,
+                epsilon=0.1,
+                delta=0.1,
+                init_offset=0,
+                local_offset=0,
+                sampling_mode=mode,
+                temperature=temperature,
+            )
+        )
+
+    def _estimate(self, masker, logits, budget, trials):
+        """Mean and sd of sum_{i in S} x_i / pi_i, as the attention path computes it."""
+        x = torch.exp(logits - logits.max())
+        budget_tensor = torch.full((*self.SHAPE[:-1], 1), budget, dtype=torch.long)
+        estimates = []
+        for trial in range(trials):
+            torch.manual_seed(9000 + trial)
+            mask = masker._create_importance_sampling_mask(
+                logits, budget_tensor, self.SHAPE[-1], self.START, torch.float32
+            )
+            # apply_inv_mask is what turns the stored pi_i into the 1/pi_i weight
+            estimates.append(float(mask.apply_inv_mask(x).sum()))
+        stacked = torch.tensor(estimates)
+        return float(stacked.mean()), float(stacked.std()), float(x.sum())
+
+    @pytest.mark.parametrize("mode", ["gumbel", "multinomial"])
+    def test_horvitz_thompson_estimator_is_unbiased(self, mode):
+        """The whole point: E[sum x_i / pi_i] must equal sum x_i.
+
+        With data = 1/pi the estimator collapses toward zero, and with the
+        merge clamp on top it saturates at the truncated sum -- either way this
+        is off by tens of percent, far outside the tolerance below.
+        """
+        logits = self._leftover_logits(spread=3.0, seed=11)
+        mean, sd, truth = self._estimate(self._masker(mode), logits, 64, trials=120)
+        relative_bias = (mean - truth) / truth
+        standard_error = sd / (120**0.5) / truth
+        assert abs(relative_bias) < max(0.05, 3 * standard_error), (
+            f"{mode}: relative bias {relative_bias:+.3%} "
+            f"(truth {truth:.3f}, mean {mean:.3f}, 1 s.e. {standard_error:.3%})"
+        )
+
+    @pytest.mark.parametrize("mode", ["gumbel", "multinomial"])
+    def test_importance_sampling_beats_uniform_variance(self, mode):
+        """Importance sampling is only worth its cost if it cuts the variance."""
+        logits = self._leftover_logits(spread=3.0, seed=12)
+        _, sd_importance, truth = self._estimate(
+            self._masker(mode), logits, 64, trials=120
+        )
+        x = torch.exp(logits - logits.max())
+        n = self.SHAPE[-1]
+        uniform_estimates = []
+        for trial in range(120):
+            generator = torch.Generator().manual_seed(9000 + trial)
+            drawn = torch.randint(0, n, (64,), generator=generator)
+            uniform_estimates.append(
+                float(x[..., torch.unique(drawn)].sum() / (64 / n))
+            )
+        sd_uniform = float(torch.tensor(uniform_estimates).std())
+        assert sd_importance < 0.5 * sd_uniform, (
+            f"{mode}: sd {sd_importance / truth:.2%} of truth vs uniform "
+            f"{sd_uniform / truth:.2%}"
+        )
+
+    def test_mask_stores_inclusion_probability_not_its_reciprocal(self):
+        """data must be pi_i in (0, 1]; apply_inv_mask is what makes it 1/pi_i.
+
+        Storing 1/pi_i would (a) invert the correction and (b) be erased by
+        merge_mask's clamp(m1 + m2, 0, 1), since every such value is >= 1.
+        """
+        logits = self._leftover_logits(spread=3.0, seed=13)
+        budget_tensor = torch.full((*self.SHAPE[:-1], 1), 64, dtype=torch.long)
+        for mode in ("gumbel", "multinomial"):
+            torch.manual_seed(3)
+            mask = self._masker(mode)._create_importance_sampling_mask(
+                logits, budget_tensor, self.SHAPE[-1], self.START, torch.float32
+            )
+            dense = mask.get_dense_mask()
+            selected = dense[dense > 0]
+            assert selected.numel() > 0
+            assert bool((selected > 0).all()) and bool((selected <= 1.0).all())
+            assert bool((selected < 1.0).any()), f"{mode} produced a hard top-k"
+            weights = mask.apply_inv_mask(torch.ones_like(dense))[dense > 0]
+            assert bool((weights >= 1.0 - 1e-3).all()), "weights must up-weight"
+            # and the clamp in merge_mask must leave them alone
+            other = torch.zeros_like(dense)
+            other[..., :4] = 1.0
+            merged = Mask.create_mask_from_dense_mask(
+                dense.shape, other, dtype=torch.float32
+            ).merge_mask(mask, inplace=False)
+            survived = merged.get_dense_mask()[..., 4:][dense[..., 4:] > 0]
+            assert torch.allclose(survived, selected[-survived.numel() :], atol=1e-6)
+
+    def test_multinomial_duplicate_draws_are_not_double_counted(self):
+        """With replacement, one key can be drawn many times; pi_i applies once."""
+        logits = torch.full(self.SHAPE, -20.0)
+        logits[..., 7] = 20.0  # essentially all mass on a single key
+        budget_tensor = torch.full((*self.SHAPE[:-1], 1), 32, dtype=torch.long)
+        torch.manual_seed(5)
+        mask = self._masker("multinomial")._create_importance_sampling_mask(
+            logits, budget_tensor, self.SHAPE[-1], self.START, torch.float32
+        )
+        dense = mask.get_dense_mask()
+        assert float(dense[..., 7].max()) <= 1.0
+        assert float(dense[..., 7].min()) > 0.0
+
+    def test_causally_masked_keys_are_never_sampled(self):
+        """expwts == 0 (attention-masked) must be -inf in the proposal.
+
+        log(clamp_min(1e-20)) floors those at a FINITE -46, which every
+        isfinite() liveness test would happily sample.
+        """
+        masker = self._masker("gumbel")
+        expwts = torch.rand(self.SHAPE) + 0.1
+        expwts[..., 256:] = 0.0
+        empty = Mask.create_empty_mask(
+            self.SHAPE, dtype=torch.float32, device=torch.device("cpu")
+        )
+        leftover = masker._get_leftover_scores(
+            expwts, empty, 0, self.SHAPE[-1], {}, {}, 1.0
+        )
+        assert bool(torch.isinf(leftover[..., 256:]).all())
+        assert bool(torch.isfinite(leftover[..., :256]).all())
+
+    def test_pq_proposal_is_rescaled_onto_the_attention_logit_axis(self):
+        """PQCache publishes raw q.k; the proposal must be scaling * q.k.
+
+        Without this, temperature=1.0 means temperature=1/sqrt(head_dim) in
+        attention space and the draw collapses onto the deterministic top-k.
+        """
+        masker = self._masker("gumbel")
+        pq_scores = torch.randn(self.SHAPE) * 30.0
+        meta = {"pq_scores": {0: pq_scores}, "pq_score_offset": {0: 0}}
+        expwts = torch.rand(self.SHAPE) + 0.1
+        empty = Mask.create_empty_mask(
+            self.SHAPE, dtype=torch.float32, device=torch.device("cpu")
+        )
+        scaling = 0.0884
+        leftover = masker._get_leftover_scores(
+            expwts, empty, 0, self.SHAPE[-1], meta, {"layer_idx": 0}, scaling
+        )
+        assert torch.allclose(leftover, pq_scores * scaling, atol=1e-5)
+
+    def test_stale_pq_scores_from_another_step_are_not_reused(self):
+        """The cache is keyed only by layer, so the leading dims must be checked."""
+        masker = self._masker("gumbel")
+        stale = torch.randn(1, 2, 8, self.SHAPE[-1])  # a prefill entry, q=8
+        meta = {"pq_scores": {0: stale}, "pq_score_offset": {0: 0}}
+        expwts = torch.rand(self.SHAPE) + 0.1  # decode, q=1
+        empty = Mask.create_empty_mask(
+            self.SHAPE, dtype=torch.float32, device=torch.device("cpu")
+        )
+        leftover = masker._get_leftover_scores(
+            expwts, empty, 0, self.SHAPE[-1], meta, {"layer_idx": 0}, 1.0
+        )
+        assert leftover.shape == self.SHAPE
+        assert torch.allclose(leftover, torch.log(expwts.clamp_min(1e-20)), atol=1e-5)
+
+    def test_grouped_query_attention_shapes(self):
+        """Llama-3.1-8B is 32 query heads over 8 KV heads; the mask is query-head."""
+        num_q_heads, num_kv_heads, head_dim = 8, 2, 16
+        seq_len_keys, seq_len_queries = 64, 1
+        keys = torch.randn(1, num_kv_heads, seq_len_keys, head_dim)
+        queries = torch.randn(1, num_q_heads, seq_len_queries, head_dim)
+        values = torch.randn(1, num_kv_heads, seq_len_keys, head_dim)
+        previous = torch.zeros(1, num_q_heads, seq_len_queries, seq_len_keys)
+        previous[..., :8] = 1.0
+        previous_mask = Mask.create_mask_from_dense_mask(
+            previous.shape, previous, dtype=torch.float32
+        )
+        for mode in ("uniform", "gumbel", "multinomial"):
+            result = self._masker(mode).add_mask(
+                keys,
+                queries,
+                values,
+                None,
+                scaling=head_dim**-0.5,
+                dropout=0.0,
+                sparse_meta_data={},
+                previous_mask=previous_mask,
+                layer_idx=0,
+            )
+            assert result.get_dense_mask().shape == previous.shape
+
+    def test_one_saturated_row_does_not_erase_other_rows_weights(self):
+        """A whole-tensor -inf threshold would set pi = 1 everywhere."""
+        from sparse_attention_hub.sparse_attention.research_attention.maskers.sampling.implementations.utils.importance_sampling_utils import (  # noqa: E501
+            gumbel_topk_with_inclusion,
+        )
+
+        n = 16
+        scores = torch.randn(1, 1, 2, n) * 3.0
+        budget = torch.tensor([[[[n], [4]]]]).reshape(1, 1, 2, 1)
+        torch.manual_seed(2)
+        _, inclusion, valid, _dense = gumbel_topk_with_inclusion(scores, budget, 1.0)
+        saturated = inclusion[0, 0, 0][valid[0, 0, 0]]
+        sampled = inclusion[0, 0, 1][valid[0, 0, 1]]
+        assert bool((saturated == 1.0).all()), "a saturated row is a census"
+        assert bool((sampled < 1.0).any()), "the other row must keep real weights"
+
+
+@pytest.mark.unit
+class TestSamplingModeConfig:
+    """The flag itself."""
+
+    def _config(self, **overrides):
+        base = dict(
+            base_rate_sampling=0.1,
+            epsilon=0.1,
+            delta=0.1,
+            init_offset=0,
+            local_offset=0,
+        )
+        base.update(overrides)
+        return AdaptiveSamplingMaskerConfig(**base)
+
+    def test_default_is_uniform(self):
+        assert self._config().sampling_mode == "uniform"
+
+    @pytest.mark.parametrize("mode", ["uniform", "gumbel", "multinomial"])
+    def test_accepts_every_documented_mode(self, mode):
+        assert self._config(sampling_mode=mode).sampling_mode == mode
+
+    def test_rejects_unknown_mode(self):
+        with pytest.raises(ValueError, match="sampling_mode must be one of"):
+            self._config(sampling_mode="importance")
+
+    def test_rejects_zero_temperature_for_importance_modes(self):
+        with pytest.raises(ValueError, match="deterministic top-k"):
+            self._config(sampling_mode="gumbel", temperature=0.0)
+
+    def test_rejects_negative_temperature(self):
+        with pytest.raises(ValueError, match="temperature must be >= 0"):
+            self._config(temperature=-1.0)

--- a/tests/unit/sparse_attention/research_attention/maskers/sampling/test_adaptive_sampling.py
+++ b/tests/unit/sparse_attention/research_attention/maskers/sampling/test_adaptive_sampling.py
@@ -696,7 +696,7 @@ class TestImportanceSamplingEstimator:
         assert bool(torch.isinf(leftover[..., 256:]).all())
         assert bool(torch.isfinite(leftover[..., :256]).all())
 
-    def test_pq_proposal_is_rescaled_onto_the_attention_logit_axis(self):
+    def test_published_proposal_is_rescaled_onto_the_attention_logit_axis(self):
         """PQCache publishes raw q.k; the proposal must be scaling * q.k.
 
         Without this, temperature=1.0 means temperature=1/sqrt(head_dim) in
@@ -704,7 +704,7 @@ class TestImportanceSamplingEstimator:
         """
         masker = self._masker("gumbel")
         pq_scores = torch.randn(self.SHAPE) * 30.0
-        meta = {"pq_scores": {0: pq_scores}, "pq_score_offset": {0: 0}}
+        meta = {"heavy_scores": {0: pq_scores}, "heavy_score_offset": {0: 0}}
         expwts = torch.rand(self.SHAPE) + 0.1
         empty = Mask.create_empty_mask(
             self.SHAPE, dtype=torch.float32, device=torch.device("cpu")
@@ -715,11 +715,11 @@ class TestImportanceSamplingEstimator:
         )
         assert torch.allclose(leftover, pq_scores * scaling, atol=1e-5)
 
-    def test_stale_pq_scores_from_another_step_are_not_reused(self):
+    def test_stale_published_scores_from_another_step_are_not_reused(self):
         """The cache is keyed only by layer, so the leading dims must be checked."""
         masker = self._masker("gumbel")
         stale = torch.randn(1, 2, 8, self.SHAPE[-1])  # a prefill entry, q=8
-        meta = {"pq_scores": {0: stale}, "pq_score_offset": {0: 0}}
+        meta = {"heavy_scores": {0: stale}, "heavy_score_offset": {0: 0}}
         expwts = torch.rand(self.SHAPE) + 0.1  # decode, q=1
         empty = Mask.create_empty_mask(
             self.SHAPE, dtype=torch.float32, device=torch.device("cpu")
@@ -806,7 +806,6 @@ class TestSamplingModeConfig:
     def test_rejects_negative_temperature(self):
         with pytest.raises(ValueError, match="temperature must be >= 0"):
             self._config(temperature=-1.0)
-
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What this does

vAttention picks its adaptive sampling budget from `(epsilon, delta, base_rate_sampling)` and then spends it on a **uniform** draw over the whole window. This PR keeps the budget rule byte-for-byte and changes only the draw, behind one flag on `AdaptiveSamplingMaskerConfig`:

| `sampling_mode` | draw |
|---|---|
| `"uniform"` *(default)* | the published vAttention draw — uniform with replacement. **Unchanged**, so no existing config moves. |
| `"multinomial"` | **exact** importance sampling. `budget` i.i.d. draws from `softmax(logits / temperature)` via `torch.multinomial`, weighted by the exact inclusion probability `pi_i = 1 - (1 - p_i) ** budget`. |
| `"gumbel"` | the Gumbel-top-k approximation of the same draw. One `topk` over `logits + temperature * Gumbel(0,1)`, weighted by `1 - exp(-exp((l_i - kappa)/temperature))` for the `(k+1)`-th perturbed order statistic `kappa`. |

Sampling **with replacement** is what makes the multinomial inclusion probability closed-form and exact; duplicates are a feature, not a problem — they collapse into one mask position, which `1 - (1-p_i)^m` already accounts for. Gumbel-top-k is one kernel cheaper and its `k` keys are distinct, so the whole budget buys distinct keys, but `pi_i` is exact only conditional on `kappa`.

Both importance modes draw only from the **leftover** keys — whatever sink, local and the heavy top-k already took is `-inf` in the proposal — and write `pi_i` into the mask. `Mask.apply_inv_mask` divides by the stored value, and *that division* is what turns `pi_i` into the Horvitz–Thompson weight `1 / pi_i`.

```python
AdaptiveSamplingMaskerConfig(
    base_rate_sampling=0.002,
    epsilon=0.1, delta=0.1,           # unchanged vAttention budget rule
    init_offset=128, local_offset=127,
    sampling_mode="multinomial",      # "uniform" (default) | "gumbel" | "multinomial"
    temperature=1.0,                  # true attention-logit units
)
```

## Results

**Llama-3.1-8B-Instruct, RULER-32k, 6 hard subsets (`fwe`, `vt`, `qa_1`, `qa_2`, `niah_multikey_2`, `niah_multikey_3`), n=100 each, `max_context_length=64000` (nothing truncated), `max_new_tokens=128`, one H200 per cell.**

Every sparse arm shares the same heavy set and the same budget rule; only the draw differs.

```python
SinkMaskerConfig(sink_size=128)
LocalMaskerConfig(window_size=127)
PQCacheConfig(heavy_size=0.008, pq_group_factor=16, pq_bits=8,
              kmeans_iter=10, init_offset=128, metric="euclidean")
AdaptiveSamplingMaskerConfig(base_rate_sampling=0.002, epsilon=0.1, delta=0.1,
                             init_offset=128, local_offset=127, ...)
```

`pq_group_factor=16, pq_bits=8` is 16 sub-vectors × 8 bits = **128 bits/key**, PQCache's own quantizer shape. The `pqcache_only` control uses `heavy_size=0.0122` so it lands at the same measured density with no sampling stage. Density is the measured mean of `research_attention_density`, not a nominal target.

| arm | draw | fwe | vt | qa_1 | qa_2 | nm2 | nm3 | **macro** | density |
|---|---|---|---|---|---|---|---|---|---|
| dense | — | 93.33 | 99.20 | 87.00 | 52.00 | 99.00 | 100.00 | **88.42** | 1.0 |
| PQCache only | no sampling stage | 81.67 | 97.60 | 82.00 | 51.00 | 89.00 | 72.00 | **78.88** | 0.02017 |
| vAttention | `uniform` | 91.67 | 98.80 | 83.00 | 48.00 | 99.00 | 100.00 | **86.75** | 0.02140 |
| **vAttention++** | `gumbel`, T=1 | 93.00 | 99.40 | 83.00 | 54.00 | 100.00 | 100.00 | **88.23** | 0.02154 |
| **vAttention++** | `multinomial`, T=1 | 93.33 | 99.40 | 87.00 | 50.00 | 100.00 | 100.00 | **88.29** | **0.02050** |

Paired per-item against `uniform` over the same 100 rows per subset (Wilcoxon signed-rank on the non-zero differences):

| arm | macro Δ | significant cells |
|---|---|---|
| `gumbel` | **+1.49** | none in either direction |
| `multinomial` | **+1.54** | none in either direction |
| dense | +1.68 | none in either direction |

Both importance modes close **~92 % of the gap to dense** and are not distinguishable from dense on any subset. The exact mode does it at *lower* measured density than the uniform baseline it beats — 2.050 % vs 2.140 %.

## The detail that decides whether this works at all

The proposal has to be on the **attention-logit axis**. PQCache publishes raw `q·k̂`; the attention logit is `scaling · q·k`, and `scaling = 1/√128 = 0.0884` for this model. Sampling the unscaled score at `temperature=1` is sampling the real logit at `temperature=0.088`.

Instrumented on real RULER rows (1 088 draws, `niah_multikey_2`, all taken from the reuse path):

| temperature on the raw score axis | mean `pi` | `pi > 0.99` | overlap with deterministic top-k |
|---|---|---|---|
| 0.0 | 1.000 | 100 % | 1.000 |
| 0.1 | 0.974 | 92.5 % | 0.998 |
| 1.0 | 0.786 | 49.2 % | **0.981** |
| 11.31 = √head_dim | 0.164 | 2.1 % | 0.500 |
| 50.0 | 0.037 | 0 % | 0.161 |

At `T=1` on the unscaled axis, 98 % of the "sample" is the deterministic top-k — the HT weights are all ≈1 and the arm is a biased truncation, not an estimator. On synthetic leftovers (n=32 000, budget 200, logit s.d. 3.0, 300 trials) it comes out *worse* than the uniform draw it replaces:

| draw | relative bias | relative s.d. |
|---|---|---|
| uniform with replacement | −13.5 % | 128 % |
| importance, T=1 on the raw score axis | **−18.3 %** | 36 % |
| importance, T=1 on the logit axis | **+0.35 %** | **3.5 %** |

`_get_leftover_scores` therefore rescales the reused scores, so `temperature` is in true-logit units on both the reuse path and the `log(expwts)` fallback.

Two smaller things folded in: keys the attention mask kills are excluded from the proposal (in the fallback they arrive as an underflowed `0.0` that `log()` floors at a *finite* −46, which any `isfinite()` liveness test would happily sample), and PQCache retains only the **current** layer's published scores — a `[b, h, q, n_clustered]` tensor per layer is ~8 GB at the question step for an 8B model at 32k — with a reuse guard on the leading dims so a prefill entry cannot be picked up at decode time.

## Tests

New tests assert the **estimator**, not the shapes — each one fails if the mask stored `1/pi`, if the proposal were left on the raw axis, or if a repeated multinomial draw were counted twice:

- unbiasedness of `sum x_i / pi_i` for both modes, with a 3-s.e. tolerance
- a >2× variance reduction against uniform at the same budget
- `pi`-not-`1/pi` direction, and that the values survive `merge_mask`'s `clamp(m1 + m2, 0, 1)`
- duplicate multinomial draws not double-counted
- causally-masked keys never sampled
- the proposal being rescaled by `scaling`
- stale published scores from another step rejected
- GQA shapes (32 query heads over 8 KV heads)
- one budget-saturated row not erasing another row's weights

`pytest tests/unit/.../maskers`: **419 passed**, 1 failed — `test_get_std_estimate_using_base_sample`, which is unseeded and **fails identically on clean `main`** at directory scope (401 passed, 1 failed there); it passes in isolation and in file scope on both. `black`, `isort`, `flake8` clean on the changed files; `mypy` adds no new errors.

## Reproducing

Runs are on a frozen worktree with the BOS fix applied, and every cell asserts exactly one BOS through the adapter's own tokenisation path before it starts — that defect changes *which needle the model returns*, so it is not a common-mode offset between arms. Method, per-cell outputs and the paired statistics: `/scratch/sj157/pr91_eval/results/{METHODS.md,TABLES.md,paired.txt}`.

## Three things worth being explicit about

**1. The threshold / budget selection is vAttention's own, untouched.** `_compute_adaptive_budget`, `_get_std_estimate_using_base_sample`, `_get_base_sample_count`, `delta_ppf` and the final `clamp(budget, min=num_base_samples, max=sampling_range)` are byte-identical to `main` — verified by extracting the block from both trees and comparing. Every mode gets the same integer budget for the same inputs; `sampling_mode` only decides how that budget is spent. The `"uniform"` branch is likewise byte-identical to `main` modulo the added `else:` indent.

**2. The importance sampling happens on the leftover indices only.** `_get_leftover_scores` sets `-inf` on two sets before any draw: everything `previous_mask` already holds (sink, local, and the heavy top-k), and everything the attention mask kills. So the sampler can only add keys the heavy stage did not take, and the two stages never contend for the same key. `"multinomial"` is exact importance sampling (`torch.multinomial` + the closed-form `1 - (1 - p_i)^m`); `"gumbel"` is the Gumbel-noise + top-k approximation of it. Both are on leftovers.

**3. It is not tied to PQCache.** The sampling stage takes its proposal from one of two places: whatever a preceding masker offered via `ResearchMasker.publish_heavy_scores` (PQCache does; nothing is required to), or `log(expwts)` — the exact attention logits `AdaptiveSamplingMasker` already computes for the budget, so the fallback costs nothing extra and works behind any heavy masker or none at all.

Measured, same protocol, `OracleTopKConfig(heavy_size=0.008)` in place of PQCache and nothing else changed:

| arm | fwe | vt | qa_1 | qa_2 | nm2 | nm3 | **macro** | density |
|---|---|---|---|---|---|---|---|---|
| Sink+Local+**OracleTopK**+AdaptiveSampling `uniform` | 90.33 | 99.20 | 85.00 | 55.00 | 100.00 | 100.00 | **88.25** | 0.02120 |
| Sink+Local+**OracleTopK**+AdaptiveSampling `multinomial` | 94.00 | 99.40 | 88.00 | 53.00 | 100.00 | 100.00 | **89.07** | **0.02026** |

Paired per-item: **+0.81 macro**, `fwe` **+3.67 (Wilcoxon p=0.0034)**, nothing significant in the other direction — again at lower measured density than the uniform arm it beats. Unit tests cover Sink+Local+{OracleTopK, PQCache}+AdaptiveSampling in both importance modes, and Sink+AdaptiveSampling with no heavy masker at all.

## How to run it

vAttention++ is the existing vAttention chain with one field changed. Swap the heavy masker for anything you like — `OracleTopKConfig`, `QuestTopKMaskerConfig`, `HashAttentionTopKMaskerConfig`, `DoubleSparsityTopKMaskerConfig`, `SocketMaskerConfig` — and nothing else moves:

```python
from sparse_attention_hub.sparse_attention.research_attention import ResearchAttentionConfig
from sparse_attention_hub.sparse_attention.research_attention.maskers.fixed.implementations import (
    LocalMaskerConfig, OracleTopKConfig, PQCacheConfig, SinkMaskerConfig,
)
from sparse_attention_hub.sparse_attention.research_attention.maskers.sampling.implementations import (
    AdaptiveSamplingMaskerConfig,
)

config = ResearchAttentionConfig(masker_configs=[
    SinkMaskerConfig(sink_size=128),
    LocalMaskerConfig(window_size=127),

    # the heavy set -- any top-k masker
    PQCacheConfig(heavy_size=0.008, pq_group_factor=16, pq_bits=8,
                  kmeans_iter=10, init_offset=128, metric="euclidean"),
    # or: OracleTopKConfig(heavy_size=0.008)

    AdaptiveSamplingMaskerConfig(
        base_rate_sampling=0.002,
        epsilon=0.1, delta=0.1,        # vAttention's budget rule, unchanged
        init_offset=128,               # = sink_size
        local_offset=127,              # = window_size
        sampling_mode="multinomial",   # "uniform" = today's vAttention
        temperature=1.0,               # true attention-logit units
    ),
])
```

Then drive it as usual — `ModelAdapterHF(model_name=..., sparse_attention_config=config, ...)`.

Three knobs that actually matter:

- **`init_offset` / `local_offset` must match the sink and local sizes**, so the sampler's window is exactly the region neither covers.
- **`epsilon` / `delta` decide whether the adaptive budget fires at all.** At `0.4` it is pinned to its `num_base_samples` floor (measured density 1.78 %, the ε/δ machinery never engages); at `0.05` it saturates toward the whole window (3.9–4.7 %). `0.1` is what lands at ~2 % at 32k.
- **`heavy_size` is heavy tokens on top of sink + local + budget**, not a total, so read the measured `research_attention_density` rather than assuming.

One thing to know when comparing arms: `uniform` draws with replacement over the whole window, so it loses budget to collisions and to re-drawing keys the heavy stage already holds, while the importance modes draw exactly `budget` distinct leftovers. At equal config the measured densities differ by ~6 % relative at 2 % and ~21 % at 4 % — report both rather than assuming they match.

## Relationship to #91

Same goal; this is a separate branch off `main` rather than a push to that branch. #91's current head fixes the `pi` direction and adds the exact with-replacement formula, but still defaults the flag on (which silently converts every existing vAttention call site), still samples the raw unscaled score axis, and no longer offers the Gumbel option. Happy to fold this into #91 instead if that is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGNGgWvfsapwTRPwh6sEn3
