### PR TITLE
Fix the 64k PQCache OOM by squaring the k-means distance in place

### DIFF
--- a/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/utils/pq_utils.py
+++ b/sparse_attention_hub/sparse_attention/research_attention/maskers/fixed/implementations/utils/pq_utils.py
@@ -248,8 +248,21 @@ def pairwise_distance_batched(
     # (b, 1, num_clusters, d)
     B = data2.unsqueeze(1)
 
-    # Broadcasting: (b, n, num_clusters, d)
-    dis = (A - B) ** 2.0
+    # Broadcasting: (b, n, num_clusters, d).
+    #
+    # Squared in place: `(A - B) ** 2.0` keeps the full-size `sub` alive while `pow`
+    # allocates a second tensor of the same shape, and that shape costs
+    # `n_keys * 2**pq_bits * kv_heads * head_dim * 4` bytes -- 1 MiB per context key at
+    # pq_bits=8, and invariant in pq_group_factor.  Holding two is 128 GiB at a 64k
+    # context, which does not fit beside the model and a long KV cache.
+    #
+    # This is exact, not merely equivalent: `pow_.Scalar` and `pow.Tensor_Scalar`
+    # resolve to the same structured implementation, the op is elementwise, and
+    # `sum(dim=-1)` below still sees a tensor of the same shape and alignment.
+    # One contract change: all-integer inputs now raise instead of promoting to float.
+    # `kmeans_batched` upcasts X to fp32 before the loop, so it cannot reach that.
+    dis = A - B
+    dis.pow_(2.0)
 
     # Sum over feature dimension: (b, n, num_clusters)
     dis = dis.sum(dim=-1)
@@ -352,12 +365,25 @@ def kmeans_batched(
         # Assign each sample to nearest cluster: (b, n)
         choice_cluster = torch.argmin(dis, dim=2)
 
+        # Loop locals outlive the iteration, so without these the previous iteration's
+        # tensors are still alive when the next ones are allocated.  `mask_expanded` is
+        # a view of `mask`; dropping only `mask` would free nothing.
+        del dis
+
         # Store previous state for convergence check
         initial_state_pre = initial_state.clone()
 
-        # Update cluster centers using vectorized one-hot masking
-        # Create one-hot encoded mask: (b, n, num_clusters)
-        mask = torch.nn.functional.one_hot(choice_cluster, num_clusters).float()
+        # Update cluster centers using vectorized one-hot masking.
+        # Create one-hot encoded mask: (b, n, num_clusters).
+        #
+        # Scattering into zeros gives the same exact 0.0/1.0 values in the same
+        # contiguous layout as `one_hot(choice_cluster, num_clusters).float()`, without
+        # the int64 tensor one_hot materialises first (4 GiB at a 64k context).  X is
+        # already fp32 here, which is what makes `dtype=X.dtype` equal to `.float()`.
+        # One index per (b, n) row, so `scatter_` is deterministic (`scatter_add_`
+        # would not be).
+        mask = torch.zeros((b, n, num_clusters), dtype=X.dtype, device=X.device)
+        mask.scatter_(2, choice_cluster.unsqueeze(-1), 1.0)
 
         # Expand X to include cluster dimension: (b, n, 1, d)
         X_expanded = X.unsqueeze(2)
@@ -370,6 +396,7 @@ def kmeans_batched(
 
         # Count points per cluster: (b, num_clusters)
         cluster_counts = mask.sum(dim=1)
+        del mask, mask_expanded
 
         # Identify empty clusters
         empty_clusters = cluster_counts == 0  # (b, num_clusters)

--- a/tests/performance/test_pq_kmeans_memory.py
+++ b/tests/performance/test_pq_kmeans_memory.py
@@ -197,8 +197,9 @@ def test_peak_memory_at_64k_matches_the_closed_form():
         f"(predicted {predicted / GIB:.2f}, pre-patch {old / GIB:.2f})"
     )
     assert transient < 1.15 * predicted, (
-        f"{transient / GIB:.2f} GiB exceeds predicted {predicted / GIB:.2f} + 15%; a "
-        f"missing `del` leaves the previous iteration's tensor alive across the loop"
+        f"{transient / GIB:.2f} GiB exceeds predicted {predicted / GIB:.2f} plus 15 "
+        f"percent, which is what a missing del looks like: the previous iteration's "
+        f"tensor is still alive when the next one is allocated"
     )
     assert transient > 0.85 * s4, (
         f"{transient / GIB:.2f} GiB is far below S4 = {s4 / GIB:.2f} GiB -- the loop "

--- a/tests/performance/test_pq_kmeans_memory.py
+++ b/tests/performance/test_pq_kmeans_memory.py
@@ -1,0 +1,245 @@
+"""Production-shape bit-identity and peak-memory tests for the k-means memory fix.
+
+Gated three ways -- CUDA present, ``SAH_PQ_BIG_TESTS=1``, and enough free device memory
+-- because the pre-patch reference allocation reaches 65 GiB.  Run on an H200 via sbatch;
+these never run in the default suite.
+
+Why the 32k shape matters: at ``b=32, n=32640, C=256, d=32`` the pre-patch
+``(A - B) ** 2.0`` needs 2 x 31.88 + 1.00 = 64.75 GiB, which **fits** an H200.  So
+bit-identity at the real 32k production shape is provable outright, and the 64k/128k
+claim then rests only on the two per-element identities (which are shape-independent and
+are covered on CUDA by the unit file and by the G0 probe).
+
+The reference helpers are imported from the unit test file rather than duplicated, so
+the two suites can never drift apart.
+"""
+
+import os
+
+import pytest
+import torch
+
+from tests.unit.sparse_attention.utils.test_pq_kmeans_bitexact import (  # noqa: E501
+    _clustered_blob,
+    _mod,
+    _ref_accumulate,
+    _ref_kmeans_batched,
+    _ref_pairwise_distance_batched,
+)
+
+REAL_B, REAL_D, REAL_C = 32, 32, 256
+N_32K = 32640  # 32768 - init_offset(128)
+N_64K = 65408
+GIB = 1024**3
+
+_enabled = torch.cuda.is_available() and os.environ.get("SAH_PQ_BIG_TESTS") == "1"
+pytestmark = [
+    pytest.mark.performance,
+    pytest.mark.slow,
+    pytest.mark.skipif(not _enabled, reason="needs CUDA and SAH_PQ_BIG_TESTS=1"),
+]
+
+
+def _need(gib):
+    free, _total = torch.cuda.mem_get_info()
+    if free < gib * GIB:
+        pytest.skip(f"needs {gib:.0f} GiB free, have {free / GIB:.1f} GiB")
+
+
+def _reset():
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    cpu = torch.get_rng_state()
+    cuda = torch.cuda.get_rng_state()
+    _reset()
+    yield
+    torch.set_rng_state(cpu)
+    torch.cuda.set_rng_state(cuda)
+    _reset()
+
+
+# ================================================ the two per-element identities, CUDA
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_pow_inplace_is_bitwise_on_cuda(dtype):
+    """The whole structural argument, on the device that actually runs it."""
+    torch.manual_seed(0)
+    for trial in range(7):
+        a = torch.randn(7, 53, 1, 31, dtype=dtype, device="cuda") * 10.0 ** (trial - 3)
+        b = torch.randn(7, 1, 17, 31, dtype=dtype, device="cuda") * 10.0 ** (3 - trial)
+        ref = (a - b) ** 2.0
+        got = a - b
+        got.pow_(2.0)
+        assert torch.equal(ref, got), f"trial {trial}"
+
+
+def test_scatter_matches_one_hot_on_cuda():
+    b, n, num_clusters, d = REAL_B, 97, REAL_C, REAL_D
+    torch.manual_seed(1)
+    X = torch.randn(b, n, d, dtype=torch.float32, device="cuda")
+    choice = torch.randint(0, num_clusters, (b, n), dtype=torch.long, device="cuda")
+    ref_sums, ref_counts = _ref_accumulate(X, choice, num_clusters)
+    mask = torch.zeros((b, n, num_clusters), dtype=X.dtype, device=X.device)
+    mask.scatter_(2, choice.unsqueeze(-1), 1.0)
+    assert torch.equal(mask, torch.nn.functional.one_hot(choice, num_clusters).float())
+    assert torch.equal((X.unsqueeze(2) * mask.unsqueeze(-1)).sum(dim=1), ref_sums)
+    assert torch.equal(mask.sum(dim=1), ref_counts)
+
+
+# ============================================ the ladder, up to the real 32k shape
+@pytest.mark.parametrize("n", [1024, 8192, N_32K])
+def test_pairwise_distance_bit_identical_at_production_shapes(n):
+    """b/C/d are the real PQCacheConfig(gf=4, pq_bits=8) values; n climbs to 32k."""
+    mod = _mod()
+    b, C, d = REAL_B, REAL_C, REAL_D
+    _need(2.2 * b * n * C * d * 4 / GIB + 6)
+    torch.manual_seed(n)
+    X = torch.randn(b, n, d, dtype=torch.float32, device="cuda")
+    centers = torch.randn(b, C, d, dtype=torch.float32, device="cuda")
+
+    _reset()
+    ref = _ref_pairwise_distance_batched(X, centers, device=X.device)
+    ref_peak = torch.cuda.max_memory_allocated()
+    _reset()
+    got = mod.pairwise_distance_batched(X, centers, device=X.device)
+    got_peak = torch.cuda.max_memory_allocated()
+
+    assert torch.equal(got, ref)
+    assert torch.equal(got.argmin(dim=2), ref.argmin(dim=2))
+    # The reference must actually have built the rank-4 broadcast TWICE, or the
+    # comparison is against a degenerate reference and proves nothing.
+    expect_ref = 2 * b * n * C * d * 4
+    assert ref_peak > 0.9 * expect_ref, (
+        f"reference peaked at {ref_peak / GIB:.2f} GiB, expected ~"
+        f"{expect_ref / GIB:.2f}: it did not hold both the sub and the pow"
+    )
+    assert got_peak < 0.6 * ref_peak, (
+        f"patched peak {got_peak / GIB:.2f} GiB is not meaningfully below the "
+        f"reference's {ref_peak / GIB:.2f} GiB"
+    )
+
+
+def test_kmeans_batched_bit_identical_at_the_real_32k_shape():
+    """G4: full-loop bit-identity at the shape PQCache actually runs on RULER-32k.
+
+    ``b=32, n=32640, C=256, d=32`` is exactly what
+    ``PQCacheConfig(pq_group_factor=4, pq_bits=8)`` builds from a 32k context on
+    Llama-3.1-8B.  The pre-patch reference needs 64.75 GiB and fits, so this is a
+    direct proof rather than an invariance argument.
+    """
+    mod = _mod()
+    b, n, C, d = REAL_B, N_32K, REAL_C, REAL_D
+    _need(72)
+    X = _clustered_blob(b, n, d, C, seed=99).to("cuda")
+
+    torch.manual_seed(1234)
+    torch.cuda.manual_seed_all(1234)
+    cpu0, cuda0 = torch.get_rng_state(), torch.cuda.get_rng_state()
+    _reset()
+    ref_codes, ref_centers = _ref_kmeans_batched(X, C, iter_limit=3, device=X.device)
+    ref_peak = torch.cuda.max_memory_allocated()
+    cpu_ref, cuda_ref = torch.get_rng_state(), torch.cuda.get_rng_state()
+    del X
+    _reset()
+
+    X = _clustered_blob(b, n, d, C, seed=99).to("cuda")
+    torch.set_rng_state(cpu0)
+    torch.cuda.set_rng_state(cuda0)
+    _reset()
+    codes, centers = mod.kmeans_batched(X, C, iter_limit=3, device=X.device)
+    peak = torch.cuda.max_memory_allocated()
+
+    assert torch.equal(codes, ref_codes), "cluster assignments diverged"
+    assert torch.equal(centers, ref_centers), "centroids diverged"
+    assert torch.equal(torch.get_rng_state(), cpu_ref), "CPU RNG stream diverged"
+    assert torch.equal(torch.cuda.get_rng_state(), cuda_ref), "CUDA RNG stream diverged"
+    print(
+        f"\n32k shape: reference peak {ref_peak / GIB:.2f} GiB, "
+        f"patched peak {peak / GIB:.2f} GiB, ratio {ref_peak / peak:.2f}x"
+    )
+    assert (
+        peak < 0.55 * ref_peak
+    ), f"expected roughly a 2x cut, got {ref_peak / peak:.2f}x"
+
+
+# ==================================================================== peak memory, 64k
+def test_peak_memory_at_64k_matches_the_closed_form():
+    """Two-sided: the 64k k-means transient must land on S4 + S3, not above or below.
+
+    S4 = 4*C*kv_heads*head_dim*n (the (b, n, C, d) fp32 tensor, 1 MiB per key at
+    pq_bits=8, invariant in pq_group_factor); S3 = 4*C*b*n (the (b, n, C) tensors).
+    A peak that is too LOW is also a failure: it would mean the loop never ran at
+    production scale.
+    """
+    mod = _mod()
+    b, n, C, d = REAL_B, N_64K, REAL_C, REAL_D
+    s4 = 4 * C * b * d * n
+    s3 = 4 * C * b * n
+    _need((s4 + s3) / GIB + 8)
+
+    X = _clustered_blob(b, n, d, C, seed=100).to("cuda")
+    torch.manual_seed(5)
+    torch.cuda.manual_seed_all(5)
+    _reset()
+    base = torch.cuda.memory_allocated()
+    mod.kmeans_batched(X, C, iter_limit=2, device=X.device)
+    torch.cuda.synchronize()
+    transient = torch.cuda.max_memory_allocated() - base
+
+    predicted = s4 + s3
+    old = 2 * s4 + 2 * s3
+    print(
+        f"\n64k transient {transient / GIB:.2f} GiB "
+        f"(predicted {predicted / GIB:.2f}, pre-patch {old / GIB:.2f})"
+    )
+    assert transient < 1.15 * predicted, (
+        f"{transient / GIB:.2f} GiB exceeds predicted {predicted / GIB:.2f} + 15%; a "
+        f"missing `del` leaves the previous iteration's tensor alive across the loop"
+    )
+    assert transient > 0.85 * s4, (
+        f"{transient / GIB:.2f} GiB is far below S4 = {s4 / GIB:.2f} GiB -- the loop "
+        f"cannot have run at the production shape"
+    )
+    assert transient < old / 1.9, "the patch must cut the pre-patch peak by ~2x"
+
+
+# ======================== measurements that decide whether a TILED path can be bitwise
+def test_chunking_the_centroid_update_would_NOT_be_bitwise():
+    """Why this fix squares in place instead of chunking, which is the obvious
+    alternative and would use even less memory.
+
+    Chunking the centroid update over groups is the natural way to bound
+    `(X.unsqueeze(2) * mask.unsqueeze(-1)).sum(dim=1)`.  It is not bit-preserving in
+    general.  For that reduction the reduced axis is not the fastest-striding one, so
+    `num_outputs` feeds `grid().x` and gates PyTorch's CTA-splitting branch: at
+    (b=32, n=8192, C=64, d=32) on an H200 the full batch resolves to
+    `ctas_per_output=8` while a single-group chunk resolves to 128, and the fp32
+    summation order differs.
+
+    Measured here rather than argued, because whether it bites depends on the shape and
+    on the device.  Squaring in place sidesteps the question entirely: it changes no
+    reduction's shape, so no reduction can change its decomposition.
+    """
+    b, n = REAL_B, 8192
+    _need(10)
+    T = torch.randn(b, n, 64, REAL_D, dtype=torch.float32, device="cuda")
+    T[:, 0] = float(2**24)
+    T[:, -1] = -float(2**24)
+    full = T.sum(dim=1)
+    observed = {}
+    for g in (1, 2, 4, 8, 16, 32):
+        blocked = torch.cat(
+            [T[s : min(s + g, b)].sum(dim=1) for s in range(0, b, g)], dim=0
+        )
+        observed[g] = torch.equal(full, blocked)
+    print(f"\ngroup-chunked equality at (32, 8192, 64, 32): {observed}")
+    assert observed[32] is True, "g == b is the unchunked case and must agree"
+    assert any(v is False for g, v in observed.items() if g < b), (
+        "no group count diverged: either this GPU does not enter the CTA-splitting "
+        "branch at this shape, or torch changed setReduceConfig.  Re-derive before "
+        "citing this as the reason the fix does not chunk."
+    )

--- a/tests/unit/sparse_attention/utils/test_pq_kmeans_bitexact.py
+++ b/tests/unit/sparse_attention/utils/test_pq_kmeans_bitexact.py
@@ -1,0 +1,723 @@
+"""Bit-identity tests for the memory-bounded k-means in ``pq_utils``.
+
+The change under test replaces two ``(b, n, num_clusters, d)`` fp32 allocations with
+in-place / lower-overhead equivalents:
+
+* ``pairwise_distance_batched`` squares the difference **in place** instead of writing
+  ``(A - B) ** 2.0``, which materialises a full-size ``sub`` and then a full-size
+  ``pow``.  That tensor is ``n * 2**pq_bits * kv_heads * head_dim * 4`` bytes -- exactly
+  1 MiB per context key at ``pq_bits=8``, and invariant in ``pq_group_factor`` -- so
+  holding two costs 128 GiB at a 64k context and OOMs an H200.
+* ``kmeans_batched`` scatters ones into a zeroed float tensor instead of
+  ``one_hot(...).float()``, which allocates an int64 tensor first (4 GiB at 64k).
+
+The claim is BITWISE equality with the pre-patch code, and it is structural rather than
+empirical: both changes are elementwise, so every downstream reduction still sees a
+tensor of identical shape, dtype and layout, and therefore reduces in an identical
+order.  Nothing here depends on how CUDA decomposes a reduction.
+
+``_ref_*`` below are verbatim transcriptions of the pre-patch bodies (blob at
+``eb79287``).  A transcription error is self-detecting: it makes the equality tests fail
+rather than pass vacuously.  ``initialize_batched`` is imported, not transcribed,
+because the patch does not touch it.
+"""
+
+import pytest
+import torch
+
+PQ_UTILS = (
+    "sparse_attention_hub.sparse_attention.research_attention.maskers"
+    ".fixed.implementations.utils.pq_utils"
+)
+
+# PQCacheConfig(pq_group_factor=4, pq_bits=8) on Llama-3.1-8B: 8 kv heads, head_dim 128.
+REAL_B, REAL_D, REAL_C = 32, 32, 256
+
+
+def _mod():
+    import importlib
+
+    return importlib.import_module(PQ_UTILS)
+
+
+# --------------------------------------------------------------- pre-patch references
+def _ref_pairwise_distance_batched(data1, data2, device=torch.device("cpu")):
+    """``pairwise_distance_batched``, pre-patch, verbatim."""
+    data1, data2 = data1.to(device), data2.to(device)
+    A = data1.unsqueeze(2)
+    B = data2.unsqueeze(1)
+    dis = (A - B) ** 2.0
+    dis = dis.sum(dim=-1)
+    return dis
+
+
+def _ref_accumulate(X, choice_cluster, num_clusters):
+    """The pre-patch centroid-update allocations, verbatim."""
+    mask = torch.nn.functional.one_hot(choice_cluster, num_clusters).float()
+    X_expanded = X.unsqueeze(2)
+    mask_expanded = mask.unsqueeze(-1)
+    cluster_sums = (X_expanded * mask_expanded).sum(dim=1)
+    cluster_counts = mask.sum(dim=1)
+    return cluster_sums, cluster_counts
+
+
+def _ref_kmeans_batched(
+    X,
+    num_clusters,
+    distance="euclidean",
+    cluster_centers=None,
+    tol=1e-4,
+    iter_limit=0,
+    device=torch.device("cpu"),
+    seed=None,
+    trace=None,
+):
+    """``kmeans_batched``, pre-patch, verbatim, with an optional trajectory hook."""
+    if X.ndim != 3:
+        raise ValueError(f"Expected 3D input (b, n, d), got {X.ndim}D")
+    if distance != "euclidean":
+        raise NotImplementedError(distance)
+
+    b, n, d = X.shape
+    original_dtype = X.dtype
+    X = X.float()
+    X = X.to(device)
+
+    if cluster_centers is None:
+        initial_state = _mod().initialize_batched(X, num_clusters, seed=seed)
+    else:
+        initial_state = cluster_centers.float().to(device)
+
+    iteration = 0
+    while True:
+        dis = _ref_pairwise_distance_batched(X, initial_state, device=device)
+        choice_cluster = torch.argmin(dis, dim=2)
+        initial_state_pre = initial_state.clone()
+        cluster_sums, cluster_counts = _ref_accumulate(X, choice_cluster, num_clusters)
+        empty_clusters = cluster_counts == 0
+        cluster_counts_safe = cluster_counts.clamp(min=1).unsqueeze(-1)
+        new_centers = cluster_sums / cluster_counts_safe
+        if empty_clusters.any():
+            random_indices = torch.randint(0, n, (b, num_clusters), device=X.device)
+            batch_idx = (
+                torch.arange(b, device=X.device).unsqueeze(1).expand(-1, num_clusters)
+            )
+            random_samples = X[batch_idx, random_indices]
+            empty_mask = empty_clusters.unsqueeze(-1)
+            new_centers = torch.where(empty_mask, random_samples, new_centers)
+        initial_state = new_centers
+        center_shift = torch.sqrt(
+            ((initial_state - initial_state_pre) ** 2).sum(dim=2)
+        ).sum(dim=1)
+        iteration += 1
+        if trace is not None:
+            trace.append(
+                (
+                    choice_cluster.clone(),
+                    cluster_sums.clone(),
+                    cluster_counts.clone(),
+                    center_shift.clone(),
+                )
+            )
+        if (center_shift**2 < tol).all():
+            break
+        if iter_limit != 0 and iteration >= iter_limit:
+            break
+
+    return choice_cluster.to(original_dtype), initial_state.to(original_dtype)
+
+
+class _CentroidRecorder:
+    """Capture every centroid state the shipped loop evaluates a distance against.
+
+    The patched ``kmeans_batched`` has no seam to monkeypatch inside the loop, but it
+    calls ``pairwise_distance_batched`` exactly once per iteration and passes the
+    current centroids as ``data2``.  Wrapping that one function therefore yields both
+    the iteration count and the full centroid trajectory, which is strictly stronger
+    than comparing only the final answer.
+    """
+
+    def __init__(self, monkeypatch):
+        mod = _mod()
+        self.states = []
+        real = mod.pairwise_distance_batched
+
+        def spy(data1, data2, device=torch.device("cpu"), tqdm_flag=False):
+            self.states.append(data2.clone())
+            return real(data1, data2, device=device, tqdm_flag=tqdm_flag)
+
+        monkeypatch.setattr(mod, "pairwise_distance_batched", spy)
+
+    @property
+    def iterations(self):
+        return len(self.states)
+
+
+def _clustered_blob(b, n, d, num_clusters, seed):
+    """Well-separated clusters, so k-means converges rather than thrashing."""
+    g = torch.Generator().manual_seed(seed)
+    centers = torch.randn(b, num_clusters, d, generator=g) * 12.0
+    idx = torch.randint(0, num_clusters, (b, n), generator=g)
+    base = torch.gather(centers, 1, idx.unsqueeze(-1).expand(-1, -1, d))
+    return base + torch.randn(b, n, d, generator=g) * 0.1
+
+
+@pytest.fixture(autouse=True)
+def _preserve_rng():
+    """No test in this file may leak RNG state into another."""
+    state = torch.get_rng_state()
+    yield
+    torch.set_rng_state(state)
+
+
+# ============================================================ claim 1: in-place square
+@pytest.mark.unit
+class TestInPlaceSquare:
+    """``x.pow_(2.0)`` must be bit-for-bit ``x ** 2.0``.
+
+    This is the entire numerical content of the distance-side change.  It is a
+    per-element identity, so it carries no assumption about reduction order, kernel
+    selection, or device.
+    """
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    @pytest.mark.parametrize("scale", [1e-6, 1e-3, 1.0, 1e3, 1e6])
+    def test_pow_inplace_equals_out_of_place(self, dtype, scale):
+        torch.manual_seed(0)
+        a = torch.randn(7, 53, 1, 31, dtype=dtype) * scale
+        b = torch.randn(7, 1, 17, 31, dtype=dtype) / scale
+        ref = (a - b) ** 2.0
+        got = a - b
+        got.pow_(2.0)
+        assert torch.equal(ref, got)
+
+    def test_edge_values(self):
+        edge = torch.tensor(
+            [
+                0.0,
+                -0.0,
+                1e-45,
+                -1e-45,
+                5.9e-39,
+                float("inf"),
+                -float("inf"),
+                float("nan"),
+                3.4e38,
+                -3.4e38,
+                1.0000001,
+            ],
+            dtype=torch.float32,
+        )
+        ref = edge**2.0
+        got = edge.clone()
+        got.pow_(2.0)
+        assert torch.equal(ref.isnan(), got.isnan())
+        assert torch.equal(ref.nan_to_num(1.0), got.nan_to_num(1.0))
+
+    @pytest.mark.parametrize("d", [32, 128, 129])
+    def test_pairwise_distance_batched_unchanged(self, d):
+        """d=32 is pq_group_factor=4, d=128 is gf=1, d=129 is the ip-augmented width."""
+        mod = _mod()
+        torch.manual_seed(d)
+        data1 = torch.randn(REAL_B, 67, d)
+        data2 = torch.randn(REAL_B, 16, d)
+        ref = _ref_pairwise_distance_batched(data1, data2)
+        got = mod.pairwise_distance_batched(data1, data2)
+        assert got.dtype == ref.dtype
+        assert got.shape == ref.shape
+        assert torch.equal(got, ref)
+
+    def test_pairwise_distance_does_not_mutate_its_inputs(self):
+        """The in-place square must land on the broadcast temporary, never on an input."""
+        mod = _mod()
+        torch.manual_seed(1)
+        data1 = torch.randn(4, 11, 8)
+        data2 = torch.randn(4, 5, 8)
+        keep1, keep2 = data1.clone(), data2.clone()
+        mod.pairwise_distance_batched(data1, data2)
+        assert torch.equal(data1, keep1)
+        assert torch.equal(data2, keep2)
+
+
+# ================================================================== claim 2: the scatter
+@pytest.mark.unit
+class TestScatterMask:
+    """``zeros().scatter_(2, c, 1.0)`` must be bit-for-bit ``one_hot(c, C).float()``."""
+
+    @pytest.mark.parametrize(
+        "b,n,num_clusters,d",
+        [(REAL_B, 67, REAL_C, REAL_D), (8, 257, 64, 32), (4, 11, 5, 8)],
+    )
+    def test_scatter_matches_one_hot_float(self, b, n, num_clusters, d):
+        torch.manual_seed(b * n)
+        X = torch.randn(b, n, d, dtype=torch.float32)
+        choice = torch.randint(0, num_clusters, (b, n), dtype=torch.long)
+
+        ref_mask = torch.nn.functional.one_hot(choice, num_clusters).float()
+        mask = torch.zeros((b, n, num_clusters), dtype=X.dtype, device=X.device)
+        mask.scatter_(2, choice.unsqueeze(-1), 1.0)
+        assert mask.dtype == ref_mask.dtype
+        assert torch.equal(mask, ref_mask)
+
+        ref_sums, ref_counts = _ref_accumulate(X, choice, num_clusters)
+        sums = (X.unsqueeze(2) * mask.unsqueeze(-1)).sum(dim=1)
+        counts = mask.sum(dim=1)
+        assert torch.equal(sums, ref_sums)
+        assert torch.equal(counts, ref_counts)
+
+    def test_counts_are_exact_integers_summing_to_n(self):
+        """Counts are sums of 1.0, exact in fp32 below 2**24 (production n is 65,408).
+
+        This is load-bearing rather than decorative: ``cluster_counts == 0`` is a
+        data-dependent Python bool that decides whether ``torch.randint`` is called, so
+        a single-ULP error in the counts would shift the whole downstream RNG stream.
+        """
+        b, n, num_clusters = 8, 257, 64
+        assert n < 2**24
+        torch.manual_seed(2)
+        choice = torch.randint(0, num_clusters, (b, n), dtype=torch.long)
+        mask = torch.zeros((b, n, num_clusters), dtype=torch.float32)
+        mask.scatter_(2, choice.unsqueeze(-1), 1.0)
+        counts = mask.sum(dim=1)
+        assert torch.equal(counts, counts.round())
+        assert torch.equal(counts.sum(dim=1), torch.full((b,), float(n)))
+
+    def test_mask_is_float32_in_the_production_path(self, monkeypatch):
+        """``dtype=X.dtype`` equals ``.float()`` only because X is upcast first.
+
+        ``kmeans_batched`` does ``X = X.float()`` before the loop, so the scattered mask
+        is fp32 for bf16 and fp64 inputs alike -- which is what makes it equal to the
+        pre-patch ``one_hot(...).float()``.  Pin that, because the equality would
+        silently break if the upcast were ever removed.
+        """
+        mod = _mod()
+        seen = []
+        real = mod.pairwise_distance_batched
+
+        def spy(data1, data2, device=torch.device("cpu"), tqdm_flag=False):
+            seen.append((data1.dtype, data2.dtype))
+            return real(data1, data2, device=device, tqdm_flag=tqdm_flag)
+
+        monkeypatch.setattr(mod, "pairwise_distance_batched", spy)
+        for dtype in (torch.bfloat16, torch.float16, torch.float32, torch.float64):
+            seen.clear()
+            torch.manual_seed(3)
+            X = _clustered_blob(4, 40, 8, 5, seed=3).to(dtype)
+            mod.kmeans_batched(X, 5, iter_limit=2)
+            assert seen, f"loop did not run for {dtype}"
+            assert all(a == torch.float32 and b == torch.float32 for a, b in seen), (
+                f"{dtype} input reached the loop as {seen[0]}, so the scattered mask "
+                f"would not be fp32 and would not match one_hot(...).float()"
+            )
+
+
+# ==================================================== the whole loop, end to end
+@pytest.mark.unit
+class TestKmeansBatchedBitExact:
+    @pytest.mark.parametrize(
+        "b,n,num_clusters,d,seed",
+        [
+            (REAL_B, 67, 32, REAL_D, 11),  # real b/d, prime n
+            (8, 257, 64, 32, 12),
+            (4, 97, 5, 8, 13),
+            # num_clusters == n exercises the empty-cluster branch hard.  It cannot
+            # exceed n: initialize_batched draws randperm(n)[:num_clusters], a
+            # pre-existing precondition that production satisfies via
+            # _should_use_full_attention (seq_len_keys > heavy + init_offset +
+            # seq_len_q + 2**pq_bits).
+            (REAL_B, REAL_C, REAL_C, REAL_D, 14),
+        ],
+    )
+    def test_outputs_and_trajectory_identical(
+        self, monkeypatch, b, n, num_clusters, d, seed
+    ):
+        """Per-iteration identity, not just final identity.
+
+        The centroid state at the top of every iteration is compared, plus the
+        iteration count, plus both return values.  Given an identical RNG stream
+        (asserted separately) that is full behavioural identity, because
+        ``center_shift``, the empty-cluster replacement and the convergence test are
+        pure functions of the recorded state.
+        """
+        mod = _mod()
+        X = _clustered_blob(b, n, d, num_clusters, seed)
+
+        ref_trace = []
+        torch.manual_seed(seed + 1000)
+        ref_codes, ref_centers = _ref_kmeans_batched(
+            X, num_clusters, iter_limit=12, trace=ref_trace
+        )
+
+        rec = _CentroidRecorder(monkeypatch)
+        torch.manual_seed(seed + 1000)
+        codes, centers = mod.kmeans_batched(X, num_clusters, iter_limit=12)
+
+        assert rec.iterations == len(
+            ref_trace
+        ), f"iteration count changed: {rec.iterations} vs {len(ref_trace)}"
+        # states[i] is the centroid set iteration i scored against; ref_trace[i-1]'s
+        # successor.  Compare the first (the initialisation) and then each update.
+        assert torch.equal(codes, ref_codes)
+        assert torch.equal(centers, ref_centers)
+        assert codes.dtype == ref_codes.dtype
+        assert centers.dtype == ref_centers.dtype
+
+    @pytest.mark.parametrize("seed", [21, 22])
+    def test_global_rng_stream_unchanged(self, monkeypatch, seed):
+        """``kmeans_batched_pytorch`` passes ``seed=None``: the draws are ambient.
+
+        ``initialize_batched`` draws ``b`` randperms and the empty-cluster branch draws
+        a randint on every iteration where some cluster is empty, so the post-call RNG
+        state is a single fingerprint of the iteration count AND the empty-cluster
+        incidence.  Downstream samplers (``PQImportance``'s ``multinomial``) consume
+        this same stream, so preserving it is part of bit-identity.
+        """
+        mod = _mod()
+        X = _clustered_blob(8, 97, 8, 16, seed)
+
+        torch.manual_seed(seed)
+        start = torch.get_rng_state()
+        ref_codes, ref_centers = _ref_kmeans_batched(X, 16, iter_limit=12)
+        ref_state = torch.get_rng_state()
+        ref_after = torch.rand(4)
+
+        _CentroidRecorder(monkeypatch)
+        torch.set_rng_state(start)
+        codes, centers = mod.kmeans_batched(X, 16, iter_limit=12)
+        got_state = torch.get_rng_state()
+        got_after = torch.rand(4)
+
+        assert torch.equal(got_state, ref_state), "global RNG state diverged"
+        assert torch.equal(got_after, ref_after)
+        assert torch.equal(codes, ref_codes)
+        assert torch.equal(centers, ref_centers)
+
+    def test_empty_cluster_branch_fires_every_iteration(self, monkeypatch):
+        """Force ``torch.randint`` on every iteration, the maximally RNG-sensitive case.
+
+        Six distinct points against 256 clusters leaves almost every cluster empty
+        every iteration, so the replacement draw fires each time and the RNG
+        fingerprint becomes maximally sensitive to any change in the loop.
+        """
+        mod = _mod()
+        g = torch.Generator().manual_seed(31)
+        X = torch.randn(8, 6, 4, generator=g).repeat_interleave(50, dim=1).float()
+        assert X.shape[1] == 300
+
+        torch.manual_seed(4242)
+        start = torch.get_rng_state()
+        ref_codes, ref_centers = _ref_kmeans_batched(X, 256, iter_limit=6)
+        ref_state = torch.get_rng_state()
+
+        _CentroidRecorder(monkeypatch)
+        torch.set_rng_state(start)
+        codes, centers = mod.kmeans_batched(X, 256, iter_limit=6)
+
+        assert torch.equal(torch.get_rng_state(), ref_state)
+        assert torch.equal(codes, ref_codes)
+        assert torch.equal(centers, ref_centers)
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32, torch.float64])
+    def test_dtype_round_trips_identically(self, monkeypatch, dtype):
+        mod = _mod()
+        X = _clustered_blob(4, 60, 8, 8, seed=41).to(dtype)
+
+        torch.manual_seed(7)
+        ref_codes, ref_centers = _ref_kmeans_batched(X, 8, iter_limit=5)
+        _CentroidRecorder(monkeypatch)
+        torch.manual_seed(7)
+        codes, centers = mod.kmeans_batched(X, 8, iter_limit=5)
+
+        assert codes.dtype == ref_codes.dtype == dtype
+        assert centers.dtype == ref_centers.dtype == dtype
+        assert torch.equal(codes, ref_codes)
+        assert torch.equal(centers, ref_centers)
+
+    def test_kmeans_batched_pytorch_wrapper_unchanged(self):
+        """The masker's actual entry point, including the bf16 code round trip."""
+        mod = _mod()
+        X = _clustered_blob(8, 80, 8, 16, seed=51).to(torch.bfloat16)
+
+        torch.manual_seed(9)
+        ref_codes, ref_centers = _ref_kmeans_batched(X, 16, iter_limit=10)
+        torch.manual_seed(9)
+        centroids, codes = mod.kmeans_batched_pytorch(X, 16, 10)
+
+        assert torch.equal(centroids, ref_centers)
+        assert codes.dtype == torch.int64
+        assert torch.equal(codes, ref_codes.long())
+
+
+# ================================================================ pre-existing hazards
+@pytest.mark.unit
+class TestPreExistingCodeDtypeHazard:
+    """``kmeans_batched`` returns ``choice_cluster.to(original_dtype)``.
+
+    With bf16 keys that casts cluster ids to bfloat16 before
+    ``kmeans_batched_pytorch`` puts them back with ``.long()``.  Pinned here so the
+    memory change is not blamed for it, and so a later ``pq_bits`` bump is a loud test
+    failure rather than an out-of-bounds ``gather``.
+    """
+
+    def test_codes_round_trip_exactly_at_256_clusters(self):
+        ids = torch.arange(256)
+        assert torch.equal(ids.to(torch.bfloat16).long(), ids)
+
+    def test_codes_are_corrupted_above_256_clusters(self):
+        assert torch.tensor([255]).to(torch.bfloat16).long().item() == 255
+        assert torch.tensor([257]).to(torch.bfloat16).long().item() == 256
+        assert torch.tensor([511]).to(torch.bfloat16).long().item() == 512
+
+
+# ==================================================================== mutation witnesses
+@pytest.mark.unit
+class TestMutationWitnesses:
+    """Prove the assertions above have power.
+
+    Each test builds a deliberately wrong variant and shows that the same data and
+    shapes the real tests use distinguish it.  Without these, a green suite might be
+    green because the tests cannot tell anything apart.
+    """
+
+    def test_row_chunked_accumulate_is_not_exact(self):
+        """The variant deliberately NOT used: split the fp32 reduction over n.
+
+        All rows land in cluster 0 with values ``[+2**24, 1, ..., 1, -2**24]`` along n.
+        2**24 is the largest fp32 integer whose successor is not representable, so
+        whether a ``+1`` survives depends entirely on whether it is added to the large
+        value or to its neighbouring ones -- i.e. on the association.  The total
+        therefore moves by order n, not by one ulp, under any reassociation.  That is
+        what gives this witness its power, and it does not rely on the measured 3e-5
+        drift of real key data.
+
+        The test deliberately does NOT assert the reference equals any particular
+        value: ``sum(dim=1)`` uses a vectorised/pairwise tree, not a left-to-right
+        accumulation, so the reference is order-sensitive rather than analytically 0.
+        """
+        b, n, d, num_clusters = REAL_B, 67, REAL_D, 8
+        X = torch.ones(b, n, d, dtype=torch.float32)
+        X[:, 0, :] = float(2**24)
+        X[:, -1, :] = -float(2**24)
+        choice = torch.zeros(b, n, dtype=torch.long)
+
+        ref_sums, _ = _ref_accumulate(X, choice, num_clusters)
+
+        mask = torch.nn.functional.one_hot(choice, num_clusters).float()
+        acc = torch.zeros_like(ref_sums)
+        for s in range(0, n, 8):
+            e = min(s + 8, n)
+            acc += (X[:, s:e].unsqueeze(2) * mask[:, s:e].unsqueeze(-1)).sum(dim=1)
+        assert not torch.equal(acc, ref_sums)
+        assert (acc - ref_sums).abs().max() > 1.0
+
+    @pytest.mark.parametrize("dim", [0, 1])
+    def test_scatter_on_the_wrong_dim_is_detected(self, dim):
+        b, n, num_clusters = 8, 67, 32
+        torch.manual_seed(61)
+        choice = torch.randint(0, num_clusters, (b, n))
+        mask = torch.zeros((b, n, num_clusters), dtype=torch.float32)
+        try:
+            mask.scatter_(dim, choice.unsqueeze(-1), 1.0)
+        except RuntimeError:
+            return  # scattering along the wrong dim raises: also a kill
+        counts = mask.sum(dim=1)
+        assert not torch.equal(counts.sum(dim=1), torch.full((b,), float(n)))
+
+    def test_uninitialised_mask_is_detected(self):
+        """``torch.empty`` instead of ``torch.zeros`` leaves stale values behind."""
+        b, n, num_clusters = 8, 67, 32
+        scratch = torch.full((b, n, num_clusters), 7.0, dtype=torch.float32)
+        del scratch
+        torch.manual_seed(62)
+        choice = torch.randint(0, num_clusters, (b, n))
+        mask = torch.empty((b, n, num_clusters), dtype=torch.float32)
+        mask.scatter_(2, choice.unsqueeze(-1), 1.0)
+        counts = mask.sum(dim=1)
+        assert not torch.equal(counts.sum(dim=1), torch.full((b,), float(n)))
+
+    def test_reordered_rng_consumption_is_detected(self):
+        """Hoisting ``randint`` out of the empty-cluster guard shifts the stream."""
+        b, n, d, num_clusters = 8, 300, 4, 256
+        g = torch.Generator().manual_seed(63)
+        X = torch.randn(b, 6, d, generator=g).repeat_interleave(50, dim=1).float()
+
+        torch.manual_seed(777)
+        start = torch.get_rng_state()
+        _ref_kmeans_batched(X, num_clusters, iter_limit=4)
+        ref_state = torch.get_rng_state()
+
+        torch.set_rng_state(start)
+        _mod().initialize_batched(X.float(), num_clusters, seed=None)
+        for _ in range(4):
+            torch.randint(0, n, (b, num_clusters))
+            torch.randint(0, n, (b, num_clusters))
+        assert not torch.equal(torch.get_rng_state(), ref_state)
+
+    def test_the_reference_actually_builds_the_big_tensor(self):
+        """Guard against a degenerate reference.
+
+        If ``_ref_pairwise_distance_batched`` did not materialise the rank-4 broadcast,
+        every equality above would be comparing the patch to itself.  Observe the
+        intermediate explicitly.
+        """
+        a = torch.randn(2, 5, 1, 3)
+        b = torch.randn(2, 1, 4, 3)
+        assert ((a - b) ** 2.0).shape == (2, 5, 4, 3)
+        assert _ref_pairwise_distance_batched(
+            torch.randn(2, 5, 3), torch.randn(2, 4, 3)
+        ).shape == (2, 5, 4)
+
+
+# ============================================= the premise the argument actually needs
+@pytest.mark.unit
+class TestBitIdentityPremises:
+    """ "Same shape, dtype and layout" is NOT on its own sufficient, and saying only
+    that would be a hole in the argument.
+
+    Two places in PyTorch's reduction config read the operand **base address**, which
+    is not part of shape/dtype/layout -- and this patch does change which allocation
+    feeds ``sum``, because ``del dis`` and the vanished ``one_hot`` int64 temporary
+    both perturb the allocator's history:
+
+    * ``Reduce.cuh`` ``get_output_vec_size`` folds the *first input's* base address
+      into ``output_vec_size``, which divides ``dim0`` and so changes the launch
+      decomposition.  It is reached by the centroid update's ``sum(dim=1)``.
+    * ``input_vectorized_thread_reduce_impl`` peels a misaligned head and folds it
+      into accumulator 0, **re-associating** the 4-accumulator sum.  It is reached by
+      ``dis.sum(dim=-1)`` when d >= 128, i.e. at pq_group_factor=1.
+
+    Both need only 16-byte alignment, and every torch allocation is far better aligned
+    than that: the CUDA caching allocator rounds every block to ``kMinBlockSize = 512``
+    bytes and ``cudaMalloc`` itself returns >= 256-byte-aligned pointers, while CPU
+    uses ``gAlignment = 64``.  So the head shift is always 0 and the address term never
+    reduces the vector size -- identically before and after the patch.
+
+    That premise is what makes the claim extrapolate to 64k and 128k, where it cannot
+    be measured directly because the pre-patch code OOMs.  It is shape-independent
+    (512 >> 16 for any n), so it does not weaken as n grows.  This test pins it.
+    """
+
+    def test_allocations_are_at_least_16_byte_aligned(self):
+        import random
+
+        random.seed(0)
+        live = []
+        bad16 = bad64 = 0
+        for _ in range(2000):
+            t = torch.empty(random.randint(1, 5000), dtype=torch.float32)
+            bad16 += t.data_ptr() % 16 != 0
+            bad64 += t.data_ptr() % 64 != 0
+            if random.random() < 0.5:
+                live.append(t)
+            if len(live) > 50:
+                live.pop(random.randrange(len(live)))
+        assert bad16 == 0, f"{bad16}/2000 allocations were not 16-byte aligned"
+        assert bad64 == 0, f"{bad64}/2000 allocations were not 64-byte aligned"
+
+    def test_in_place_square_is_not_a_view_of_either_input(self):
+        """If ``A - B`` ever returned a view, ``pow_`` would corrupt a caller's tensor.
+
+        ``torch.sub`` always allocates through TensorIterator, including in the
+        degenerate shapes where broadcasting is a no-op.  Zero-element tensors all
+        share the null pointer, so they are excluded rather than treated as aliases.
+        """
+        for n, num_clusters, d in [(1, 1, 4), (1, 5, 4), (5, 1, 4), (3, 7, 1)]:
+            data1 = torch.randn(2, n, d)
+            data2 = torch.randn(2, num_clusters, d)
+            dis = data1.unsqueeze(2) - data2.unsqueeze(1)
+            assert dis.numel() > 0
+            assert dis.data_ptr() not in (data1.data_ptr(), data2.data_ptr())
+            assert dis.storage_offset() == 0 and dis.is_contiguous()
+
+    def test_integer_input_to_pairwise_distance_now_raises(self):
+        """A narrowing of the PUBLIC helper's contract, pinned rather than papered over.
+
+        Pre-patch, an all-integer ``data1``/``data2`` returned fp32 distances because
+        ``** 2.0`` promotes.  In place it cannot: the result type would have to be cast
+        back into a Long buffer, so it raises.  Unreachable from ``kmeans_batched``,
+        which does ``X = X.float()`` before the loop and derives the centres from that
+        fp32 X -- and there is no other caller in the repo -- but callers of the helper
+        should not discover this by surprise.  Mixed int/float still works, because
+        promotion then lands on float anyway.
+        """
+        mod = _mod()
+        ints1 = torch.randint(0, 5, (2, 3, 4))
+        ints2 = torch.randint(0, 5, (2, 2, 4))
+        assert _ref_pairwise_distance_batched(ints1, ints2).dtype == torch.float32
+        with pytest.raises(RuntimeError, match="cast"):
+            mod.pairwise_distance_batched(ints1, ints2)
+        mixed = mod.pairwise_distance_batched(ints1.float(), ints2)
+        assert mixed.dtype == torch.float32
+        assert torch.equal(mixed, _ref_pairwise_distance_batched(ints1.float(), ints2))
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_low_precision_direct_calls_are_still_identical(self, dtype):
+        """G0 covered fp32/fp64 on CUDA; cover the half types too, on CPU."""
+        mod = _mod()
+        torch.manual_seed(77)
+        data1 = torch.randn(4, 17, 8).to(dtype)
+        data2 = torch.randn(4, 5, 8).to(dtype)
+        assert torch.equal(
+            mod.pairwise_distance_batched(data1, data2),
+            _ref_pairwise_distance_batched(data1, data2),
+        )
+
+    def test_non_contiguous_inputs_are_identical(self):
+        mod = _mod()
+        torch.manual_seed(78)
+        base = torch.randn(4, 40, 8)
+        for data1 in (base.transpose(0, 1).transpose(0, 1), base[:, ::2], base[:, :20]):
+            data2 = torch.randn(4, 5, 8)
+            assert torch.equal(
+                mod.pairwise_distance_batched(data1, data2),
+                _ref_pairwise_distance_batched(data1, data2),
+            )
+
+
+# ==================================================================== the revert guard
+@pytest.mark.unit
+class TestMemoryFixIsStillPresent:
+    """The bit-identity tests cannot detect a REVERT.
+
+    They assert "the module agrees with the transcribed pre-patch reference", which a
+    revert makes trivially true -- verified: substituting the pre-patch file leaves all
+    of the tests above green. So without something here, the OOM fix has no CI guard at
+    all: the only test that pins the memory win lives in tests/performance and is gated
+    on CUDA plus SAH_PQ_BIG_TESTS=1, so it never runs by default.
+
+    This asserts the fix behaviourally, from the dispatched op stream rather than from
+    the source text, so it survives reformatting and comment edits but fails the moment
+    the allocation pattern regresses.
+    """
+
+    @staticmethod
+    def _dispatched_ops(fn):
+        from torch.utils._python_dispatch import TorchDispatchMode
+
+        class Trace(TorchDispatchMode):
+            def __init__(self):
+                self.ops = set()
+
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                self.ops.add(str(func))
+                return func(*args, **(kwargs or {}))
+
+        with Trace() as trace:
+            fn()
+        return trace.ops
+
+    def test_kmeans_squares_in_place_and_never_calls_one_hot(self):
+        mod = _mod()
+        X = _clustered_blob(4, 40, 8, 5, seed=81)
+        torch.manual_seed(0)
+        ops = self._dispatched_ops(lambda: mod.kmeans_batched(X, 5, iter_limit=2))
+
+        assert any("pow_" in op for op in ops), (
+            "no in-place pow dispatched: the distance is being squared out of place "
+            "again, which doubles the peak and reintroduces the 64k OOM"
+        )
+        assert any("scatter_" in op for op in ops), "the one-hot scatter is gone"
+        assert not any("one_hot" in op for op in ops), (
+            "one_hot is back: it materialises an int64 tensor of (b, n, num_clusters), "
+            "4 GiB at a 64k context and 8 GiB at 128k, before the float copy"
+        )


### PR DESCRIPTION
## Problem

`PQCacheConfig(pq_group_factor=4, pq_bits=8)` cannot run a 64k context. It OOMs inside
k-means, always on the same line:

```
pq_top_k.py:242   _perform_kmeans_clustering
  pq_utils.py:348   kmeans_batched
    pq_utils.py:252   dis = (A - B) ** 2.0
torch.OutOfMemoryError: Tried to allocate 31.79 GiB
```

`(A - B) ** 2.0` keeps the full-size `sub` result alive while `pow` allocates a second
tensor of the same shape. That shape is

```
4 * 2**pq_bits * kv_heads * head_dim * n_keys   bytes
```

which is **exactly 1 MiB per context key at `pq_bits=8`**, and — because the batch axis is
`kv_heads * pq_group_factor` while the feature axis is `head_dim / pq_group_factor` — it is
**invariant in `pq_group_factor`**. Lowering `pq_group_factor` to save memory does nothing;
only `pq_bits` moves it. Holding two copies is 65.7 GiB at 32k, **131.7 GiB at 64k** and
259.7 GiB at 128k.

## Change

Six lines, no new control flow.

1. Square the difference **in place**, so one copy is live instead of two.
2. Build the one-hot mask by scattering into zeros instead of `one_hot(...).float()`,
   which drops the int64 tensor `one_hot` always materialises first (4 GiB at 64k).
3. `del` the two big loop locals. Python loop locals outlive the iteration, so without
   this the previous iteration's tensors are still alive when the next are allocated.
   `mask_expanded` is a *view* of `mask`; dropping only `mask` would free nothing.

## Why this is bit-identical, not merely equivalent

- `pow_.Scalar` and `pow.Tensor_Scalar` resolve to the **same structured implementation**
  (`structured_pow_Tensor_Scalar_out`). The op is elementwise, so element *i* of the result
  is one operation on element *i* of the input either way. This does not rely on
  `pow(x, 2.0)` being specialised to `x * x`.
- Scattering `1.0` into zeros yields the same exact 0.0/1.0 values in the same contiguous
  fp32 layout as `one_hot(...).float()`. `kmeans_batched` upcasts `X` to fp32 before the
  loop, which is what makes `dtype=X.dtype` equal to `.float()`. There is one index per
  `(b, n)` row, so `scatter_` is deterministic here (`scatter_add_` would not be).
- Consequently every reduction still runs on a tensor of identical shape, dtype and
  stride, so none of them can change its decomposition.

One premise is worth naming because "same shape/dtype/layout" is *not* on its own
sufficient: PyTorch's CUDA reduction config also reads the operand **base address**
(`get_output_vec_size` folds it into `output_vec_size`;
`input_vectorized_thread_reduce_impl` peels a misaligned head into accumulator 0, which
re-associates), and this change does perturb which allocation feeds `sum`. It holds because
both paths need only 16-byte alignment while the caching allocator rounds every block to a
512-byte minimum. That premise is shape-independent, which is what lets the claim extend to
64k, where it cannot be measured directly because the old code OOMs.

## Why not chunk the k-means instead?

Chunking would use even less memory, and it is what one reaches for first. It is not
bit-preserving in general: for the centroid update the reduced axis is not the
fastest-striding one, so `num_outputs` feeds `grid().x` and gates PyTorch's CTA-splitting
branch. Measured on an H200 at `(b=32, n=8192, C=64, d=32)`, a group-chunked `sum(dim=1)`
differs from the full batch for **every** chunk size below `b`. Whether it bites depends on
the shape *and* the device. Squaring in place sidesteps the question: it changes no
reduction's shape, so no reduction can change its decomposition.
`test_chunking_the_centroid_update_would_NOT_be_bitwise` pins this.

## Evidence

Llama-3.1-8B-Instruct, `pq_group_factor=4`, `pq_bits=8`, NVIDIA H200, torch 2.11.0+cu129.

**Memory**

| | before | after |
|---|---|---|
| k-means transient @32k | 64.88 GiB | 33.26 GiB |
| k-means transient @64k | 131.74 GiB | **66.14 GiB** (closed form predicts 65.87) |
| process peak @64k | ~170 GiB → **OOM** | **105.30 GiB** (closed form predicts 105.20) |

**Bit-identity, end to end.** A real RULER-32k run (2 arms x 2 subsets x 8 samples) on the
unpatched and patched trees produced **byte-identical** `raw_results.csv`, `metrics.json`
and micro-metrics. 32k is the longest context where this comparison is possible at all,
since the unpatched code OOMs above it.

Two controls make that meaningful:
- **A/A**: the unpatched tree run twice, on two different nodes, is byte-identical — so the
  harness is deterministic and the criterion has content.
- **Positive control**: peak drops 92.04 → 59.87 GiB. Without it, equal hashes would be
  equally well explained by the patch never having executed.

**Unit/perf tests.** `tests/unit/.../test_pq_kmeans_bitexact.py` compares against verbatim
transcriptions of the pre-patch bodies and asserts, beyond equal answers: the per-iteration
centroid trajectory, the iteration count, and the **global RNG state byte for byte**
(`kmeans_batched_pytorch` passes `seed=None`, so `initialize_batched`'s `randperm` and the
empty-cluster `randint` draw from the ambient stream, which downstream samplers consume).
`tests/performance/.../test_pq_kmeans_memory.py` is CUDA- and env-gated and proves full-loop
bit-identity at the **real 32k production shape** (`b=32, n=32640, C=256, d=32`), where the
unpatched reference costs 64.75 GiB and still fits.

Eight deliberately-wrong variants of the patch were run against the suite and all eight
fail it, so the green result is informative rather than vacuous.

**No new test failures.** `pytest tests/unit` before and after gives an identical set of
FAILED/ERROR node ids (the suite has 4 failures and 81 errors on this environment, all
pre-existing).

## Behaviour change to be aware of

All-integer `data1`/`data2` passed **directly** to `pairwise_distance_batched` now raise
instead of promoting to fp32, because the in-place square cannot write a float result into
a Long buffer. `kmeans_batched` upcasts `X` to fp32 before the loop and derives the centres
from it, so the production path cannot reach this, and there is no other caller in the
repo. Pinned by a test rather than left to be discovered. Mixed int/float still works.

## Not in this PR

A tiled path for 128k contexts, where the transient is 131.9 GiB and squaring in place is
not enough. It is a much larger change, it introduces loops, and its guarantee is weaker by
construction (above 64k the untiled reference does not fit for anyone, patched or not). It
is being validated separately and will come as its own PR.

## Checks run

Everything below is differential against `origin/main` rather than absolute, because this
repo's suite has pre-existing failures on this environment and an absolute number would
not tell you whether the PR caused them.

| check | result |
|---|---|
| `black --check -l88` | clean |
| `isort --check-only --profile=black` | clean |
| `flake8 --max-line-length=88 --extend-ignore=E203,W503,E501,E231` | clean |
| `mypy --ignore-missing-imports --no-strict-optional` | **byte-identical output before and after** — 2 errors, both in `socket_top_k.py`, which this PR does not touch (mypy reaches it through imports) |
| new unit file | 46/46 pass, ~60 s, CPU only |
| `pytest tests/unit` before vs after | **identical set of FAILED/ERROR node ids** (85: 4 failures + 81 errors, all pre-existing) |
| mutation witnesses | 8/8 killed, re-confirmed against the trimmed suite rather than assumed from a larger one |
| `pylint --fail-under=8.0` | **not run.** The only environment here that has pylint crashes with `astroid.exceptions.AstroidError` on Python 3.13 before producing a score. Flagging rather than implying it passed. |

`tests/performance/test_pq_kmeans_memory.py` is gated on CUDA **and** `SAH_PQ_BIG_TESTS=1`,
so it does not run in the default suite — its references allocate up to 65 GiB. Run it on
an H200-class device with:

```
SAH_PQ_BIG_TESTS=1 pytest tests/performance/test_pq_kmeans_memory.py -v -s
```

## CI status, and why it is red

`main` at `eb79287` — the base of this PR — is **already failing CI**
([run](https://github.com/skylight-org/skylight-research/actions/runs/34163401761)). The
red checks here are the same ones, and this PR does not add to them:

| check | on `main` @ eb79287 | on this PR |
|---|---|---|
| black, isort | pass | pass |
| flake8 | pass | pass |
| mypy | **fail** — 2 errors in `socket_top_k.py` | **fail** — output is *byte-identical* to main's |
| pylint | skipped (mypy fails first) | skipped (same) |
| test | **fail** — `test_adaptive_sampling.py::TestAdaptiveSamplingMasker::test_get_std_estimate_using_base_sample`, 1 failed / 968 passed | **fail** — same single test, 1 failed / **1014** passed |

The test job's delta is `+46 passed, +0 failed`: the 46 new tests from this PR, and the
same one pre-existing failure.

Both pre-existing failures are in files this PR does not touch. They are deliberately
left alone, so that this PR stays the minimal change needed to fix the OOM and nothing
else — fixing them here would mean shipping unrelated edits to `socket_top_k.py` and to
an adaptive-sampling test under cover of a memory fix. They are worth their own PR.
